### PR TITLE
chore: update mockery version in Makefile.ci, and add installation for cloud-native-postgres component definition in setup.

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -41,5 +41,5 @@ install-tools: ## Install development tools
 	@echo "🔧 Installing development tools..."
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
 	go install github.com/air-verse/air@v1.62.0
-	go install github.com/vektra/mockery/v2@v2.65.0
+	go install github.com/vektra/mockery/v2@v2.53.4
 	@echo "✅ Development tools installed"

--- a/Makefile.k8s
+++ b/Makefile.k8s
@@ -186,6 +186,8 @@ deploy-and-verify: ## Deploy application and verify it's running
 	@echo "☸️ Deploying Fern Platform application..."
 	@echo "📁 Creating namespace..."
 	@kubectl create namespace fern-platform > /dev/null 2>&1 || echo "✅ Namespace already exists"
+	@echo "🔧 Applying CNPG component definition..."
+	@vela def apply deployments/components/cnpg.cue
 	@echo "🚀 Applying KubeVela application..."
 	@kubectl apply -f deployments/fern-platform-kubevela.yaml
 	@echo "⏳ Waiting for initial deployment (60s)..."


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the mockery tool version in Makefile.ci and added a step to install the cloud-native-postgres component definition during Kubernetes setup.

- **Dependencies**
  - Downgraded mockery from v2.65.0 to v2.53.4.

- **Setup**
  - Added installation of the CNPG component definition in the deployment process.

<!-- End of auto-generated description by cubic. -->

