### PR TITLE
refactor: update to gateway.cue to fix vela workflow apply 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ kubectl get pods -n cnpg-system
 vela def apply deployments/components/cnpg.cue
 
 # Apply Gateway component definition (optional)
-vela def apply deployments/components/gateway.yaml
+vela def apply deployments/components/gateway.cue
 
 # Verify component definitions are installed
 vela def list

--- a/deployments/components/gateway.cue
+++ b/deployments/components/gateway.cue
@@ -15,7 +15,7 @@ gateway: {
 				let ingressMetaName = context.name + nameSuffix
 				let ig  = [for i in context.outputs if (i.kind == "Ingress") && (i.metadata.name == ingressMetaName) {i}][0]
 				igs: *null | _
-				if ig != _|_ if ig.status != _|_ if ig.status.loadbalancer != _|_ if len(ig.status.loadbalancer.ingress) > 0 {
+				if ig != _|_ if ig.status != _|_ if ig.status.loadbalancer != _|_ if ig.status.loadbalancer.ingress != _|_ if len(ig.status.loadbalancer.ingress) > 0 {
 				  igs: ig.status.loadbalancer.ingress[0]
 				}
 				igr: *null | _

--- a/deployments/components/gateway.cue
+++ b/deployments/components/gateway.cue
@@ -14,31 +14,31 @@ gateway: {
 				}
 				let ingressMetaName = context.name + nameSuffix
 				let ig  = [for i in context.outputs if (i.kind == "Ingress") && (i.metadata.name == ingressMetaName) {i}][0]
-				igs: *null | string
-				if ig != _|_ if ig.status != _|_ if ig.status.loadbalancer != _|_ {
+				igs: *null | _
+				if ig != _|_ if ig.status != _|_ if ig.status.loadbalancer != _|_ if len(ig.status.loadbalancer.ingress) > 0 {
 				  igs: ig.status.loadbalancer.ingress[0]
 				}
-				igr: *null | string
-				if ig != _|_ if ig.spec != _|_  {
+				igr: *null | _
+				if ig != _|_ if ig.spec != _|_ if ig.spec.rules != _|_ if len(ig.spec.rules) > 0 {
 				  igr: ig.spec.rules[0]
 				}
-				if igs == _|_ {
+				if igs == null {
 				  message: "No loadBalancer found, visiting by using 'vela port-forward " + context.appName + "'\\n"
 				}
-				if igs != _|_ {
+				if igs != null {
 				  if igs.ip != _|_ {
-				    if igr.host != _|_ {
+				    if igr != null && igr.host != _|_ {
 				      message: "Visiting URL: " + igr.host + ", IP: " + igs.ip + "\\n"
 				    }
-				    if igr.host == _|_ {
+				    if igr == null || igr.host == _|_ {
 				      message: "Host not specified, visit the cluster or load balancer in front of the cluster, IP: " + igs.ip + "\\n"
 				    }
 				  }
 				  if igs.ip == _|_ {
-				    if igr.host != _|_ {
+				    if igr != null && igr.host != _|_ {
 				      message: "Visiting URL: " + igr.host + "\\n"
 				    }
-				    if igs.host == _|_ {
+				    if igr == null || igr.host == _|_ {
 				      message: "Host not specified, visit the cluster or load balancer in front of the cluster\\n"
 				    }
 				  }


### PR DESCRIPTION
**Receiving the following issue for vela workflow :** 
- id: 4cqeougyow
    name: deploy-keycloak
    type: apply-component
    phase: failed
    message: function call error for : CollectHealthStatus: app=fern-platform, comp=keycloak, trait=gateway, evaluate status message error: compile status template: igr: 2 errors in empty disjunction: (and 2 more errors) (value: cue/format: unsupported node type <nil>)
  - id: snbz9d2fd4
    name: wait-for-infrastructure
    type: suspend
    phase: skipped
  - id: myxrqhh6p3
    name: deploy-application
    type: apply-component
    phase: skipped


**added fixes for :** 
More null safety
Many if ... != _|_ checks added to avoid runtime errors when fields are missing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed runtime errors in the gateway.cue file by adding more null safety checks, resolving Vela workflow apply failures.

- **Bug Fixes**
  - Added checks for missing fields to prevent unsupported node type errors during status evaluation.

<!-- End of auto-generated description by cubic. -->

