### PR TITLE
feat: support authentication with external identity providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/guidewire-oss/fern-platform
 go 1.24
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/99designs/gqlgen v0.17.78
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/gin-contrib/cors v1.7.6

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/99designs/gqlgen v0.17.78 h1:bhIi7ynrc3js2O8wu1sMQj1YHPENDt3jQGyifoBvoVI=
 github.com/99designs/gqlgen v0.17.78/go.mod h1:yI/o31IauG2kX0IsskM4R894OCCG1jXJORhtLQqB7Oc=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=

--- a/internal/domains/auth/interfaces/interfaces_suite_test.go
+++ b/internal/domains/auth/interfaces/interfaces_suite_test.go
@@ -1,0 +1,13 @@
+package interfaces_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInterfaces(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Interfaces Suite")
+}

--- a/internal/domains/auth/interfaces/middleware_adapter.go
+++ b/internal/domains/auth/interfaces/middleware_adapter.go
@@ -1,6 +1,7 @@
 package interfaces
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -14,20 +15,38 @@ import (
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 )
 
+// AuthService defines the subset of AuthenticationService behavior the middleware needs.
+// Concrete application.AuthenticationService should implement these methods.
+type AuthService interface {
+	ValidateSession(ctx context.Context, sid string) (*domain.Session, error)
+	AuthenticateWithOAuth(ctx context.Context, userInfo application.UserInfo, t application.TokenInfo, ip, ua string) (*application.AuthenticateResult, error)
+	Logout(ctx context.Context, sid string) error
+}
+
+// OAuthAdapterIface defines the subset of OAuth adapter behavior the middleware needs.
+// The concrete OAuthAdapter should implement these methods.
+type OAuthAdapterIface interface {
+	GenerateState() (string, error)
+	BuildAuthURL(state string, codeChallenge ...string) string
+	ExchangeCodeForToken(code, verifier string) (*application.TokenInfo, error)
+	GetUserInfo(accessToken string) (*application.UserInfo, error)
+	BuildProviderLogoutURL(idToken string) string
+}
+
 // AuthMiddlewareAdapter provides Gin middleware using auth domain services
 type AuthMiddlewareAdapter struct {
-	authService  *application.AuthenticationService
+	authService  AuthService
 	authzService *application.AuthorizationService
-	oauthAdapter *OAuthAdapter
+	oauthAdapter OAuthAdapterIface
 	config       *config.AuthConfig
 	logger       *logging.Logger
 }
 
 // NewAuthMiddlewareAdapter creates a new auth middleware adapter
 func NewAuthMiddlewareAdapter(
-	authService *application.AuthenticationService,
+	authService AuthService,
 	authzService *application.AuthorizationService,
-	oauthAdapter *OAuthAdapter,
+	oauthAdapter OAuthAdapterIface,
 	config *config.AuthConfig,
 	logger *logging.Logger,
 ) *AuthMiddlewareAdapter {
@@ -53,11 +72,10 @@ func (m *AuthMiddlewareAdapter) RequireAuth() gin.HandlerFunc {
 		// 1. Try to get token from Authorization header
 		authHeader := c.GetHeader("Authorization")
 
-		if strings.HasPrefix(authHeader, "Bearer ") {
-			accessToken := strings.TrimPrefix(authHeader, "Bearer ")
-
+		authHeaderLower := strings.ToLower(authHeader)
+		if strings.HasPrefix(authHeaderLower, "bearer ") {
+			accessToken := authHeader[7:]
 			// Extract user info and craete session
-
 			// Get user info
 			userInfo, err := m.oauthAdapter.GetUserInfo(accessToken)
 			if err != nil {
@@ -120,10 +138,16 @@ func (m *AuthMiddlewareAdapter) RequireAdmin() gin.HandlerFunc {
 
 		user, exists := m.getUserFromContext(c)
 		if !exists || !user.IsAdmin() {
-			m.logger.WithRequest(c.GetString("request_id"), c.Request.Method, c.Request.URL.Path).
-				WithField("user_id", user.UserID).
-				WithField("user_role", user.Role).
-				Warn("Admin access denied - insufficient privileges")
+			// guard against nil user fields in logs
+			if user != nil {
+				m.logger.WithRequest(c.GetString("request_id"), c.Request.Method, c.Request.URL.Path).
+					WithField("user_id", user.UserID).
+					WithField("user_role", user.Role).
+					Warn("Admin access denied - insufficient privileges")
+			} else {
+				m.logger.WithRequest(c.GetString("request_id"), c.Request.Method, c.Request.URL.Path).
+					Warn("Admin access denied - insufficient privileges (no user in context)")
+			}
 
 			if m.isAPIRequest(c) {
 				c.JSON(403, gin.H{"error": "Admin privileges required"})
@@ -165,8 +189,8 @@ func (m *AuthMiddlewareAdapter) RequireManager() gin.HandlerFunc {
 	}
 }
 
-// generateCodeVerifier creates a random 43-128 character string
-func generateCodeVerifier() (string, error) {
+// GenerateCodeVerifier creates a random 43-128 character string
+func GenerateCodeVerifier() (string, error) {
 	verifierBytes := make([]byte, 32)
 	_, err := rand.Read(verifierBytes)
 	if err != nil {
@@ -175,8 +199,8 @@ func generateCodeVerifier() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(verifierBytes), nil
 }
 
-// generateCodeChallenge creates a base64url-encoded SHA256 hash of the verifier
-func generateCodeChallenge(verifier string) string {
+// GenerateCodeChallenge creates a base64url-encoded SHA256 hash of the verifier
+func GenerateCodeChallenge(verifier string) string {
 	hash := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(hash[:])
 }
@@ -206,13 +230,13 @@ func (m *AuthMiddlewareAdapter) StartOAuthFlow() gin.HandlerFunc {
 			// PKCE Auth Flow
 
 			// Generate code_verifier and code_challenge
-			codeVerifier, err := generateCodeVerifier()
+			codeVerifier, err := GenerateCodeVerifier()
 			if err != nil {
 				m.logger.WithError(err).Error("Failed to generate PKCE code_verifier")
 				c.JSON(500, gin.H{"error": "Failed to generate PKCE verifier"})
 				return
 			}
-			codeChallenge := generateCodeChallenge(codeVerifier)
+			codeChallenge := GenerateCodeChallenge(codeVerifier)
 
 			// Store pkce_verifier in session/cookie for validation
 			c.SetCookie("pkce_verifier", codeVerifier, 600, "/", "", isSecure, true)

--- a/internal/domains/auth/interfaces/middleware_adapter_test.go
+++ b/internal/domains/auth/interfaces/middleware_adapter_test.go
@@ -1,0 +1,1502 @@
+package interfaces
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/guidewire-oss/fern-platform/internal/domains/auth/application"
+	"github.com/guidewire-oss/fern-platform/internal/domains/auth/domain"
+	"github.com/guidewire-oss/fern-platform/pkg/config"
+	"github.com/guidewire-oss/fern-platform/pkg/logging"
+)
+
+// TokenInfo represents OAuth token information
+type TokenInfo struct {
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	ExpiresAt    int64
+}
+
+// Mock implementations
+type MockAuthService struct {
+	mock.Mock
+}
+
+func (m *MockAuthService) AuthenticateWithOAuth(ctx context.Context, userInfo domain.User, tokenInfo TokenInfo, clientIP string, userAgent string) (*application.AuthenticateResult, error) {
+	args := m.Called(ctx, userInfo, tokenInfo, clientIP, userAgent)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*application.AuthenticateResult), args.Error(1)
+}
+
+func (m *MockAuthService) ValidateSession(ctx context.Context, sessionID string) (*domain.Session, error) {
+	args := m.Called(ctx, sessionID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Session), args.Error(1)
+}
+
+func (m *MockAuthService) Logout(ctx context.Context, sessionID string) error {
+	args := m.Called(ctx, sessionID)
+	return args.Error(0)
+}
+
+type MockAuthzService struct {
+	mock.Mock
+}
+
+type MockOAuthAdapter struct {
+	mock.Mock
+}
+
+func (m *MockOAuthAdapter) GetUserInfo(accessToken string) (*domain.User, error) {
+	args := m.Called(accessToken)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.User), args.Error(1)
+}
+
+func (m *MockOAuthAdapter) GenerateState() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockOAuthAdapter) BuildAuthURL(state string) string {
+	args := m.Called(state)
+	return args.String(0)
+}
+
+func (m *MockOAuthAdapter) buildAuthURLWithPKCE(state string, codeChallenge string) string {
+	args := m.Called(state, codeChallenge)
+	return args.String(0)
+}
+
+func (m *MockOAuthAdapter) ExchangeCodeForToken(code string, codeVerifier string) (*TokenInfo, error) {
+	args := m.Called(code, codeVerifier)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*TokenInfo), args.Error(1)
+}
+
+func (m *MockOAuthAdapter) BuildProviderLogoutURL(idToken string) string {
+	args := m.Called(idToken)
+	return args.String(0)
+}
+
+// MockLogger implements a simplified logging interface for testing
+type MockLogger struct {
+	mock.Mock
+}
+
+func (m *MockLogger) WithError(err error) *MockLogger {
+	return m
+}
+
+func (m *MockLogger) WithRequest(requestID, method, path string) *MockLogger {
+	return m
+}
+
+func (m *MockLogger) WithField(key string, value interface{}) *MockLogger {
+	return m
+}
+
+func (m *MockLogger) WithFields(fields map[string]interface{}) *MockLogger {
+	return m
+}
+
+func (m *MockLogger) Error(msg string) {
+	m.Called(msg)
+}
+
+func (m *MockLogger) Warn(msg string) {
+	m.Called(msg)
+}
+
+func (m *MockLogger) Debug(msg string) {
+	m.Called(msg)
+}
+
+func (m *MockLogger) Info(msg string) {
+	m.Called(msg)
+}
+
+func (m *MockLogger) Infof(format string, args ...interface{}) {
+	m.Called(format, args)
+}
+
+// Test fixtures
+func createTestUser(role domain.UserRole, groups []domain.UserGroup) *domain.User {
+	return &domain.User{
+		UserID: "test-user",
+		Email:  "test@example.com",
+		Role:   role,
+		Groups: groups,
+	}
+}
+
+func createTestSession(user *domain.User) *domain.Session {
+	return &domain.Session{
+		SessionID: "test-session-id",
+		User:      user,
+		IDToken:   "test-id-token",
+	}
+}
+
+// Helper function to create a user that satisfies IsAdmin() method
+func createAdminUser() *domain.User {
+	return &domain.User{
+		UserID: "admin-user",
+		Email:  "admin@example.com",
+		Role:   domain.RoleAdmin,
+		Groups: nil,
+	}
+}
+
+// Helper function to create a user that satisfies IsTeamManager() method
+func createManagerUser() *domain.User {
+	return &domain.User{
+		UserID: "manager-user",
+		Email:  "manager@example.com",
+		Role:   domain.RoleAdmin,
+		Groups: nil,
+	}
+}
+
+func setupTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	return router
+}
+
+// TestAuthMiddlewareAdapter wraps AuthMiddlewareAdapter for testing
+type TestAuthMiddlewareAdapter struct {
+	authService  *MockAuthService
+	authzService *MockAuthzService
+	oauthAdapter *MockOAuthAdapter
+	config       *config.AuthConfig
+	logger       *logging.Logger
+}
+
+// RequireAuth delegates to the mock for testing
+func (t *TestAuthMiddlewareAdapter) RequireAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !t.config.Enabled || !t.config.OAuth.Enabled {
+			c.Next()
+			return
+		}
+
+		var sessionID string
+
+		// 1. Try to get token from Authorization header
+		authHeader := c.GetHeader("Authorization")
+
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			accessToken := strings.TrimPrefix(authHeader, "Bearer ")
+
+			// Get user info
+			userInfo, err := t.oauthAdapter.GetUserInfo(accessToken)
+			if err != nil {
+				c.JSON(400, gin.H{"error": "Failed to get user information due to: " + err.Error()})
+				return
+			}
+
+			tokenInfo := TokenInfo{AccessToken: accessToken}
+
+			//Authenticate user
+			result, err := t.authService.AuthenticateWithOAuth(
+				c.Request.Context(),
+				*userInfo,
+				tokenInfo,
+				c.ClientIP(),
+				c.GetHeader("User-Agent"),
+			)
+			if err != nil {
+				c.JSON(500, gin.H{"error": "Authentication failed"})
+				return
+			}
+			sessionID = result.Session.SessionID
+		}
+
+		// 2. If not in header, try cookie
+		if sessionID == "" {
+			cookie, err := c.Cookie("session_id")
+			if err != nil || cookie == "" {
+				t.handleUnauthenticated(c)
+				return
+			}
+			sessionID = cookie
+		}
+
+		session, err := t.authService.ValidateSession(c.Request.Context(), sessionID)
+		if err != nil {
+			t.handleUnauthenticated(c)
+			return
+		}
+
+		// Set user context
+		t.setUserContext(c, session.User, session)
+		c.Next()
+	}
+}
+
+// RequireAdmin delegates to mock for testing
+func (t *TestAuthMiddlewareAdapter) RequireAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// First ensure user is authenticated
+		t.RequireAuth()(c)
+		if c.IsAborted() {
+			return
+		}
+
+		user, exists := t.getUserFromContext(c)
+		if !exists || !user.IsAdmin() {
+			if t.isAPIRequest(c) {
+				c.JSON(403, gin.H{"error": "Admin privileges required"})
+			} else {
+				c.JSON(403, gin.H{"error": "Access denied - admin privileges required"})
+			}
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// RequireManager delegates to mock for testing
+func (t *TestAuthMiddlewareAdapter) RequireManager() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// First ensure user is authenticated
+		t.RequireAuth()(c)
+		if c.IsAborted() {
+			return
+		}
+
+		user, exists := t.getUserFromContext(c)
+		if !exists || !user.IsTeamManager() {
+			if t.isAPIRequest(c) {
+				c.JSON(403, gin.H{"error": "Manager privileges required"})
+			} else {
+				c.JSON(403, gin.H{"error": "Access denied - manager privileges required"})
+			}
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// StartOAuthFlow for testing
+func (t *TestAuthMiddlewareAdapter) StartOAuthFlow() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !t.config.OAuth.Enabled {
+			c.JSON(400, gin.H{"error": "OAuth not enabled"})
+			return
+		}
+
+		// Generate state parameter for security
+		state, err := t.oauthAdapter.GenerateState()
+		if err != nil {
+			c.JSON(500, gin.H{"error": "Failed to start authentication"})
+			return
+		}
+
+		// Store state in session/cookie for validation
+		isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
+		c.SetCookie("oauth_state", state, 600, "/", "", isSecure, true) // 10 minutes
+
+		authURL := ""
+		if t.config.OAuth.ClientSecret == "" {
+			// PKCE Auth Flow
+			codeVerifier, err := generateCodeVerifier()
+			if err != nil {
+				c.JSON(500, gin.H{"error": "Failed to generate PKCE verifier"})
+				return
+			}
+			codeChallenge := generateCodeChallenge(codeVerifier)
+
+			// Store pkce_verifier in session/cookie for validation
+			c.SetCookie("pkce_verifier", codeVerifier, 600, "/", "", isSecure, true)
+
+			// Build auth URL with PKCE parameters
+			authURL = t.oauthAdapter.buildAuthURLWithPKCE(state, codeChallenge)
+		} else {
+			// Build authorization URL
+			authURL = t.oauthAdapter.BuildAuthURL(state)
+		}
+
+		c.Redirect(302, authURL)
+	}
+}
+
+// HandleOAuthCallback for testing
+func (t *TestAuthMiddlewareAdapter) HandleOAuthCallback() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !t.config.OAuth.Enabled {
+			c.JSON(400, gin.H{"error": "OAuth not enabled"})
+			return
+		}
+
+		// Validate state parameter
+		state := c.Query("state")
+		expectedState, err := c.Cookie("oauth_state")
+		if err != nil || state != expectedState {
+			c.JSON(400, gin.H{"error": "Invalid state parameter"})
+			return
+		}
+
+		// Get authorization code
+		code := c.Query("code")
+		if code == "" {
+			c.JSON(400, gin.H{"error": "Authorization code required"})
+			return
+		}
+
+		// Get code_verifier from cookie - this will dictate if we are using PKCE
+		codeVerifier, _ := c.Cookie("pkce_verifier")
+
+		// Exchange code for token
+		tokenInfo, err := t.oauthAdapter.ExchangeCodeForToken(code, codeVerifier)
+		if err != nil {
+			c.JSON(400, gin.H{"error": "Token exchange failed"})
+			return
+		}
+
+		// Get user info
+		userInfo, err := t.oauthAdapter.GetUserInfo(tokenInfo.AccessToken)
+		if err != nil {
+			c.JSON(400, gin.H{"error": "Failed to get user information"})
+			return
+		}
+
+		// Authenticate user
+		result, err := t.authService.AuthenticateWithOAuth(
+			c.Request.Context(),
+			*userInfo,
+			*tokenInfo,
+			c.ClientIP(),
+			c.GetHeader("User-Agent"),
+		)
+		if err != nil {
+			c.JSON(500, gin.H{"error": "Authentication failed"})
+			return
+		}
+
+		// Set session cookie
+		t.setSessionCookie(c, result.Session.SessionID)
+
+		// Clear state cookie
+		isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
+		c.SetCookie("oauth_state", "", -1, "/", "", isSecure, true)
+
+		// Redirect to dashboard or intended page
+		redirectURL := c.DefaultQuery("redirect", "/")
+		c.Redirect(http.StatusFound, redirectURL)
+	}
+}
+
+// Logout for testing
+func (t *TestAuthMiddlewareAdapter) Logout() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		sessionID, err := c.Cookie("session_id")
+		if err == nil && sessionID != "" {
+			// Get session for ID token
+			session, _ := t.authService.ValidateSession(c.Request.Context(), sessionID)
+
+			// Invalidate session
+			t.authService.Logout(c.Request.Context(), sessionID)
+
+			// Clear session cookie
+			isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
+			c.SetCookie("session_id", "", -1, "/", "", isSecure, true)
+
+			// Build provider logout URL
+			var providerLogoutURL string
+			if session != nil {
+				providerLogoutURL = t.oauthAdapter.BuildProviderLogoutURL(session.IDToken)
+			} else {
+				providerLogoutURL = t.oauthAdapter.BuildProviderLogoutURL("")
+			}
+
+			// For AJAX requests, return JSON response
+			if c.GetHeader("Content-Type") == "application/json" || c.GetHeader("X-Requested-With") == "XMLHttpRequest" {
+				c.JSON(200, gin.H{
+					"message":    "Logged out successfully",
+					"logout_url": providerLogoutURL,
+				})
+				return
+			}
+
+			// For direct requests, redirect to provider logout
+			c.Redirect(302, providerLogoutURL)
+			return
+		}
+
+		// No session to logout
+		c.Redirect(302, "/auth/login")
+	}
+}
+
+// Helper methods for TestAuthMiddlewareAdapter
+func (t *TestAuthMiddlewareAdapter) handleUnauthenticated(c *gin.Context) {
+	// Redirect to login for browser requests, return 401 for API requests
+	if t.isAPIRequest(c) {
+		c.JSON(401, gin.H{"error": "Authentication required"})
+	} else {
+		c.Redirect(302, "/auth/login")
+	}
+	c.Abort()
+}
+
+func (t *TestAuthMiddlewareAdapter) isAPIRequest(c *gin.Context) bool {
+	return strings.HasPrefix(c.Request.URL.Path, "/api/") ||
+		strings.Contains(c.GetHeader("Accept"), "application/json") ||
+		strings.Contains(c.GetHeader("Content-Type"), "application/json")
+}
+
+func (t *TestAuthMiddlewareAdapter) setUserContext(c *gin.Context, user *domain.User, session *domain.Session) {
+	c.Set("user", user)
+	c.Set("user_id", user.UserID)
+	c.Set("user_role", string(user.Role))
+	c.Set("session", session)
+}
+
+func (t *TestAuthMiddlewareAdapter) getUserFromContext(c *gin.Context) (*domain.User, bool) {
+	user, exists := c.Get("user")
+	if !exists {
+		return nil, false
+	}
+
+	u, ok := user.(*domain.User)
+	return u, ok
+}
+
+func (t *TestAuthMiddlewareAdapter) setSessionCookie(c *gin.Context, sessionID string) {
+	// Set secure cookie for 24 hours
+	isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
+	c.SetCookie("session_id", sessionID, 86400, "/", "", isSecure, true)
+}
+
+func createTestAdapter(authService *MockAuthService, authzService *MockAuthzService, oauthAdapter *MockOAuthAdapter, authConfig *config.AuthConfig) *TestAuthMiddlewareAdapter {
+	// Create a real logger instance for the adapter since the constructor expects *logging.Logger
+	logger := &logging.Logger{} // This should work if logging.Logger has a zero-value constructor
+
+	return &TestAuthMiddlewareAdapter{
+		authService:  authService,
+		authzService: authzService,
+		oauthAdapter: oauthAdapter,
+		config:       authConfig,
+		logger:       logger,
+	}
+}
+
+func TestNewAuthMiddlewareAdapter(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{}
+	logger := &logging.Logger{}
+
+	adapter := &TestAuthMiddlewareAdapter{
+		authService:  authService,
+		authzService: authzService,
+		oauthAdapter: oauthAdapter,
+		config:       authConfig,
+		logger:       logger,
+	}
+
+	assert.NotNil(t, adapter)
+	assert.Equal(t, authService, adapter.authService)
+	assert.Equal(t, authzService, adapter.authzService)
+	assert.Equal(t, oauthAdapter, adapter.oauthAdapter)
+	assert.Equal(t, authConfig, adapter.config)
+	assert.Equal(t, logger, adapter.logger)
+}
+
+func TestRequireAuth_AuthDisabled(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: false,
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireAuth_OAuthDisabled(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: false,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireAuth_BearerToken_Success(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	user := createTestUser(domain.RoleUser, nil)
+	session := createTestSession(user)
+	userInfo := &domain.User{Email: "test@example.com"}
+	authResult := &application.AuthenticateResult{
+		User:      user,
+		Session:   session,
+		IsNewUser: false,
+	}
+
+	oauthAdapter.On("GetUserInfo", "test-token").Return(userInfo, nil)
+	authService.On("AuthenticateWithOAuth", mock.Anything, *userInfo, mock.AnythingOfType("TokenInfo"), mock.Anything, mock.Anything).Return(authResult, nil)
+	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		user, exists := GetAuthUser(c)
+		assert.True(t, exists)
+		assert.Equal(t, "test-user", user.UserID)
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	oauthAdapter.AssertExpectations(t)
+	authService.AssertExpectations(t)
+}
+
+func TestRequireAuth_BearerToken_GetUserInfoFails(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	oauthAdapter.On("GetUserInfo", "test-token").Return(nil, errors.New("token invalid"))
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	oauthAdapter.AssertExpectations(t)
+}
+
+func TestRequireAuth_Cookie_Success(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	user := createTestUser(domain.RoleUser, nil)
+	session := createTestSession(user)
+
+	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		user, exists := GetAuthUser(c)
+		assert.True(t, exists)
+		assert.Equal(t, "test-user", user.UserID)
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	authService.AssertExpectations(t)
+}
+
+func TestRequireAuth_NoSessionCookie_API(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/api/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "Authentication required", response["error"])
+}
+
+func TestRequireAuth_NoSessionCookie_Web(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/auth/login", w.Header().Get("Location"))
+}
+
+func TestRequireAuth_InvalidSession(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	authService.On("ValidateSession", mock.Anything, "invalid-session").Return(nil, errors.New("session not found"))
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "invalid-session"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/auth/login", w.Header().Get("Location"))
+	authService.AssertExpectations(t)
+}
+
+func TestRequireAdmin_Success(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	adminUser := createAdminUser()
+	session := createTestSession(adminUser)
+
+	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAdmin())
+	router.GET("/admin/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "admin success"})
+	})
+
+	req := httptest.NewRequest("GET", "/admin/test", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	authService.AssertExpectations(t)
+}
+
+func TestRequireManager_Success(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	managerUser := createManagerUser()
+	session := createTestSession(managerUser)
+
+	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireManager())
+	router.GET("/manager/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "manager success"})
+	})
+
+	req := httptest.NewRequest("GET", "/manager/test", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	authService.AssertExpectations(t)
+}
+
+func TestStartOAuthFlow_OAuthDisabled(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled: false,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.GET("/auth/login", adapter.StartOAuthFlow())
+
+	req := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestStartOAuthFlow_WithClientSecret(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled:      true,
+			ClientSecret: "test-secret",
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	oauthAdapter.On("GenerateState").Return("test-state", nil)
+	oauthAdapter.On("BuildAuthURL", "test-state").Return("https://provider.com/auth?state=test-state")
+
+	router := setupTestRouter()
+	router.GET("/auth/login", adapter.StartOAuthFlow())
+
+	req := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://provider.com/auth?state=test-state", w.Header().Get("Location"))
+
+	// Check that oauth_state cookie was set
+	cookies := w.Header()["Set-Cookie"]
+	found := false
+	for _, cookie := range cookies {
+		if strings.Contains(cookie, "oauth_state=test-state") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "oauth_state cookie should be set")
+
+	oauthAdapter.AssertExpectations(t)
+}
+
+func TestStartOAuthFlow_PKCE(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled:      true,
+			ClientSecret: "", // Empty triggers PKCE flow
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	oauthAdapter.On("GenerateState").Return("test-state", nil)
+	oauthAdapter.On("buildAuthURLWithPKCE", "test-state", mock.AnythingOfType("string")).Return("https://provider.com/auth?state=test-state&code_challenge=challenge")
+
+	router := setupTestRouter()
+	router.GET("/auth/login", adapter.StartOAuthFlow())
+
+	req := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://provider.com/auth?state=test-state&code_challenge=challenge", w.Header().Get("Location"))
+
+	// Check that both oauth_state and pkce_verifier cookies were set
+	cookies := w.Header()["Set-Cookie"]
+	stateFound := false
+	verifierFound := false
+	for _, cookie := range cookies {
+		if strings.Contains(cookie, "oauth_state=test-state") {
+			stateFound = true
+		}
+		if strings.Contains(cookie, "pkce_verifier=") {
+			verifierFound = true
+		}
+	}
+	assert.True(t, stateFound, "oauth_state cookie should be set")
+	assert.True(t, verifierFound, "pkce_verifier cookie should be set")
+
+	oauthAdapter.AssertExpectations(t)
+}
+
+func TestHandleOAuthCallback_Success(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	user := createTestUser(domain.RoleUser, nil)
+	session := createTestSession(user)
+	userInfo := &domain.User{Email: "test@example.com"}
+	tokenInfo := &TokenInfo{AccessToken: "access-token"}
+	authResult := &application.AuthenticateResult{
+		User:      user,
+		Session:   session,
+		IsNewUser: false,
+	}
+
+	oauthAdapter.On("ExchangeCodeForToken", "auth-code", "").Return(tokenInfo, nil)
+	oauthAdapter.On("GetUserInfo", "access-token").Return(userInfo, nil)
+	authService.On("AuthenticateWithOAuth", mock.Anything, *userInfo, *tokenInfo, mock.Anything, mock.Anything).Return(authResult, nil)
+
+	router := setupTestRouter()
+	router.GET("/auth/callback", adapter.HandleOAuthCallback())
+
+	req := httptest.NewRequest("GET", "/auth/callback?code=auth-code&state=test-state", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/", w.Header().Get("Location"))
+
+	// Check that session_id cookie was set
+	cookies := w.Header()["Set-Cookie"]
+	sessionFound := false
+	for _, cookie := range cookies {
+		if strings.Contains(cookie, "session_id=test-session-id") {
+			sessionFound = true
+			break
+		}
+	}
+	assert.True(t, sessionFound, "session_id cookie should be set")
+
+	oauthAdapter.AssertExpectations(t)
+	authService.AssertExpectations(t)
+}
+
+func TestHandleOAuthCallback_InvalidState(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.GET("/auth/callback", adapter.HandleOAuthCallback())
+
+	req := httptest.NewRequest("GET", "/auth/callback?code=auth-code&state=wrong-state", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "Invalid state parameter", response["error"])
+}
+
+func TestLogout_Success(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	user := createTestUser(domain.RoleUser, nil)
+	session := createTestSession(user)
+
+	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
+	authService.On("Logout", mock.Anything, "test-session-id").Return(nil)
+	oauthAdapter.On("BuildProviderLogoutURL", "test-id-token").Return("https://provider.com/logout")
+
+	router := setupTestRouter()
+	router.GET("/auth/logout", adapter.Logout())
+
+	req := httptest.NewRequest("GET", "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://provider.com/logout", w.Header().Get("Location"))
+
+	authService.AssertExpectations(t)
+	oauthAdapter.AssertExpectations(t)
+}
+
+func TestLogout_NoSession(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.GET("/auth/logout", adapter.Logout())
+
+	req := httptest.NewRequest("GET", "/auth/logout", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/auth/login", w.Header().Get("Location"))
+}
+
+func TestIsAPIRequest(t *testing.T) {
+	adapter := &AuthMiddlewareAdapter{}
+
+	tests := []struct {
+		name     string
+		path     string
+		headers  map[string]string
+		expected bool
+	}{
+		{
+			name:     "API path",
+			path:     "/api/users",
+			expected: true,
+		},
+		{
+			name:     "JSON Accept header",
+			path:     "/users",
+			headers:  map[string]string{"Accept": "application/json"},
+			expected: true,
+		},
+		{
+			name:     "JSON Content-Type header",
+			path:     "/users",
+			headers:  map[string]string{"Content-Type": "application/json"},
+			expected: true,
+		},
+		{
+			name:     "Regular web request",
+			path:     "/users",
+			headers:  map[string]string{"Accept": "text/html"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest("GET", tt.path, nil)
+
+			for key, value := range tt.headers {
+				c.Request.Header.Set(key, value)
+			}
+
+			result := adapter.isAPIRequest(c)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetAuthUser(t *testing.T) {
+	user := createTestUser(domain.RoleUser, nil)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("user", user)
+
+	retrievedUser, exists := GetAuthUser(c)
+	assert.True(t, exists)
+	assert.Equal(t, user, retrievedUser)
+
+	// Test when user doesn't exist
+	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
+	retrievedUser2, exists2 := GetAuthUser(c2)
+	assert.False(t, exists2)
+	assert.Nil(t, retrievedUser2)
+}
+
+func TestGetAuthSession(t *testing.T) {
+	user := createTestUser(domain.RoleUser, nil)
+	session := createTestSession(user)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("session", session)
+
+	retrievedSession, exists := GetAuthSession(c)
+	assert.True(t, exists)
+	assert.Equal(t, session, retrievedSession)
+
+	// Test when session doesn't exist
+	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
+	retrievedSession2, exists2 := GetAuthSession(c2)
+	assert.False(t, exists2)
+	assert.Nil(t, retrievedSession2)
+}
+
+func TestIsAdmin(t *testing.T) {
+	// Test with admin user
+	adminUser := createAdminUser()
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("user", adminUser)
+
+	assert.True(t, IsAdmin(c))
+
+	// Test with non-admin user
+	regularUser := createTestUser(domain.RoleUser, nil)
+	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c2.Set("user", regularUser)
+
+	assert.False(t, IsAdmin(c2))
+
+	// Test with no user
+	c3, _ := gin.CreateTestContext(httptest.NewRecorder())
+	assert.False(t, IsAdmin(c3))
+}
+
+func TestIsTeamManager(t *testing.T) {
+	// Test with manager user
+	managerUser := createManagerUser()
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("user", managerUser)
+
+	assert.True(t, IsTeamManager(c))
+
+	// Test with non-manager user
+	regularUser := createTestUser(domain.RoleUser, nil)
+	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c2.Set("user", regularUser)
+
+	assert.False(t, IsTeamManager(c2))
+
+	// Test with no user
+	c3, _ := gin.CreateTestContext(httptest.NewRecorder())
+	assert.False(t, IsTeamManager(c3))
+}
+
+func TestIsManagerForTeam(t *testing.T) {
+	// Create user with team-specific manager group
+	groups := []domain.UserGroup{
+		{GroupName: "team1-managers"},
+		{GroupName: "team2-users"},
+	}
+	user := createTestUser(domain.RoleUser, groups)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set("user", user)
+
+	assert.True(t, IsManagerForTeam(c, "team1"))
+	assert.False(t, IsManagerForTeam(c, "team2"))
+	assert.False(t, IsManagerForTeam(c, "team3"))
+
+	// Test with no user
+	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
+	assert.False(t, IsManagerForTeam(c2, "team1"))
+}
+
+func TestCanAccessTeamProjects(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     domain.UserRole
+		groups   []domain.UserGroup
+		team     string
+		expected bool
+	}{
+		{
+			name:     "Admin can access any team",
+			role:     domain.RoleAdmin,
+			groups:   nil,
+			team:     "anyteam",
+			expected: true,
+		},
+		{
+			name: "User with manager group can access team",
+			role: domain.RoleUser,
+			groups: []domain.UserGroup{
+				{GroupName: "team1-managers"},
+			},
+			team:     "team1",
+			expected: true,
+		},
+		{
+			name: "User with user group can access team",
+			role: domain.RoleUser,
+			groups: []domain.UserGroup{
+				{GroupName: "team1-users"},
+			},
+			team:     "team1",
+			expected: true,
+		},
+		{
+			name: "User with slash prefix group can access team",
+			role: domain.RoleUser,
+			groups: []domain.UserGroup{
+				{GroupName: "/team1-users"},
+			},
+			team:     "team1",
+			expected: true,
+		},
+		{
+			name: "User without team group cannot access team",
+			role: domain.RoleUser,
+			groups: []domain.UserGroup{
+				{GroupName: "team2-users"},
+			},
+			team:     "team1",
+			expected: false,
+		},
+		{
+			name:     "User with no groups cannot access team",
+			role:     domain.RoleUser,
+			groups:   nil,
+			team:     "team1",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var user *domain.User
+			if tt.role == domain.RoleAdmin {
+				user = createAdminUser()
+				user.Groups = tt.groups
+			} else {
+				user = createTestUser(tt.role, tt.groups)
+			}
+
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Set("user", user)
+
+			result := CanAccessTeamProjects(c, tt.team)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+
+	// Test with no user
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	assert.False(t, CanAccessTeamProjects(c, "team1"))
+}
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	verifier, err := generateCodeVerifier()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, verifier)
+
+	// Verify it's base64url encoded
+	decoded, err := base64.RawURLEncoding.DecodeString(verifier)
+	assert.NoError(t, err)
+	assert.Len(t, decoded, 32) // Should be 32 bytes
+}
+
+func TestGenerateCodeChallenge(t *testing.T) {
+	verifier := "test-verifier-string"
+	challenge := generateCodeChallenge(verifier)
+
+	assert.NotEmpty(t, challenge)
+
+	// Verify it's base64url encoded
+	_, err := base64.RawURLEncoding.DecodeString(challenge)
+	assert.NoError(t, err)
+
+	// Should be deterministic
+	challenge2 := generateCodeChallenge(verifier)
+	assert.Equal(t, challenge, challenge2)
+}
+
+func TestSetUserContext(t *testing.T) {
+	adapter := &TestAuthMiddlewareAdapter{}
+	user := createTestUser(domain.RoleUser, nil)
+	session := createTestSession(user)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	adapter.setUserContext(c, user, session)
+
+	// Verify all context values are set correctly
+	contextUser, exists := c.Get("user")
+	assert.True(t, exists)
+	assert.Equal(t, user, contextUser)
+
+	userID, exists := c.Get("user_id")
+	assert.True(t, exists)
+	assert.Equal(t, "test-user", userID)
+
+	userRole, exists := c.Get("user_role")
+	assert.True(t, exists)
+	assert.Equal(t, string(domain.RoleUser), userRole)
+
+	contextSession, exists := c.Get("session")
+	assert.True(t, exists)
+	assert.Equal(t, session, contextSession)
+}
+
+func TestSetSessionCookie(t *testing.T) {
+	adapter := &AuthMiddlewareAdapter{}
+
+	// Create test context and recorder
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	adapter.setSessionCookie(c, "test-session-id")
+
+	// Check that the cookie was set in the response
+	cookies := w.Header()["Set-Cookie"]
+
+	found := false
+	for _, cookie := range cookies {
+		if strings.Contains(cookie, "session_id=test-session-id") {
+			found = true
+			// Verify cookie properties
+			assert.Contains(t, cookie, "HttpOnly")
+			assert.Contains(t, cookie, "Path=/")
+			assert.Contains(t, cookie, "Max-Age=86400")
+			break
+		}
+	}
+	assert.True(t, found, "session_id cookie should be set")
+}
+
+func TestRequireAuth_AuthenticationFails(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		Enabled: true,
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	userInfo := &domain.User{Email: "test@example.com"}
+	oauthAdapter.On("GetUserInfo", "test-token").Return(userInfo, nil)
+	authService.On("AuthenticateWithOAuth", mock.Anything, *userInfo, mock.AnythingOfType("TokenInfo"), mock.Anything, mock.Anything).Return(nil, errors.New("authentication failed"))
+
+	router := setupTestRouter()
+	router.Use(adapter.RequireAuth())
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	// Debug what we actually got
+	responseBody := w.Body.String()
+	t.Logf("Actual response body: %q", responseBody)
+
+	// Try to extract just the first JSON object if there are multiples
+	var response map[string]string
+	decoder := json.NewDecoder(strings.NewReader(responseBody))
+	err := decoder.Decode(&response)
+	require.NoError(t, err)
+	assert.Equal(t, "Authentication failed", response["error"])
+
+	oauthAdapter.AssertExpectations(t)
+	authService.AssertExpectations(t)
+}
+
+func TestHandleOAuthCallback_MissingCode(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	router := setupTestRouter()
+	router.GET("/auth/callback", adapter.HandleOAuthCallback())
+
+	req := httptest.NewRequest("GET", "/auth/callback?state=test-state", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "Authorization code required", response["error"])
+}
+
+func TestHandleOAuthCallback_TokenExchangeFails(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	oauthAdapter.On("ExchangeCodeForToken", "auth-code", "").Return(nil, errors.New("token exchange failed"))
+
+	router := setupTestRouter()
+	router.GET("/auth/callback", adapter.HandleOAuthCallback())
+
+	req := httptest.NewRequest("GET", "/auth/callback?code=auth-code&state=test-state", nil)
+	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "Token exchange failed", response["error"])
+
+	oauthAdapter.AssertExpectations(t)
+}
+
+func TestStartOAuthFlow_StateGenerationFails(t *testing.T) {
+	authService := &MockAuthService{}
+	authzService := &MockAuthzService{}
+	oauthAdapter := &MockOAuthAdapter{}
+	authConfig := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled: true,
+		},
+	}
+	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+
+	oauthAdapter.On("GenerateState").Return("", errors.New("state generation failed"))
+
+	router := setupTestRouter()
+	router.GET("/auth/login", adapter.StartOAuthFlow())
+
+	req := httptest.NewRequest("GET", "/auth/login", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "Failed to start authentication", response["error"])
+
+	oauthAdapter.AssertExpectations(t)
+}

--- a/internal/domains/auth/interfaces/middleware_adapter_test.go
+++ b/internal/domains/auth/interfaces/middleware_adapter_test.go
@@ -1,1502 +1,740 @@
-package interfaces
+package interfaces_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"net/http"
+	_ "net/http"
 	"net/http/httptest"
-	"strings"
-	"testing"
+	_ "strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
 	"github.com/guidewire-oss/fern-platform/internal/domains/auth/application"
 	"github.com/guidewire-oss/fern-platform/internal/domains/auth/domain"
+	"github.com/guidewire-oss/fern-platform/internal/domains/auth/interfaces"
 	"github.com/guidewire-oss/fern-platform/pkg/config"
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 )
 
-// TokenInfo represents OAuth token information
-type TokenInfo struct {
-	AccessToken  string
-	RefreshToken string
-	IDToken      string
-	ExpiresAt    int64
+type fakeAuthService struct {
+	validateFn func(ctx context.Context, sid string) (*domain.Session, error)
+	authFn     func(ctx context.Context, u application.UserInfo, t application.TokenInfo, ip, ua string) (*application.AuthenticateResult, error)
+	logoutFn   func(ctx context.Context, sid string) error
 }
 
-// Mock implementations
-type MockAuthService struct {
-	mock.Mock
+func (f *fakeAuthService) ValidateSession(ctx context.Context, sid string) (*domain.Session, error) {
+	return f.validateFn(ctx, sid)
+}
+func (f *fakeAuthService) AuthenticateWithOAuth(ctx context.Context, u application.UserInfo, t application.TokenInfo, ip, ua string) (*application.AuthenticateResult, error) {
+	return f.authFn(ctx, u, t, ip, ua)
+}
+func (f *fakeAuthService) Logout(ctx context.Context, sid string) error {
+	return f.logoutFn(ctx, sid)
 }
 
-func (m *MockAuthService) AuthenticateWithOAuth(ctx context.Context, userInfo domain.User, tokenInfo TokenInfo, clientIP string, userAgent string) (*application.AuthenticateResult, error) {
-	args := m.Called(ctx, userInfo, tokenInfo, clientIP, userAgent)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+type fakeOAuthAdapter struct {
+	state     string
+	stateErr  error
+	authURL   string
+	token     *application.TokenInfo
+	tokenErr  error
+	user      *application.UserInfo
+	userErr   error
+	logoutURL string
+}
+
+func (f *fakeOAuthAdapter) GenerateState() (string, error) { return f.state, f.stateErr }
+func (f *fakeOAuthAdapter) BuildAuthURL(state string, codeChallenge ...string) string {
+	if len(codeChallenge) > 0 {
+		return f.authURL + "?cc=" + codeChallenge[0]
 	}
-	return args.Get(0).(*application.AuthenticateResult), args.Error(1)
+	return f.authURL
 }
-
-func (m *MockAuthService) ValidateSession(ctx context.Context, sessionID string) (*domain.Session, error) {
-	args := m.Called(ctx, sessionID)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*domain.Session), args.Error(1)
+func (f *fakeOAuthAdapter) ExchangeCodeForToken(code, verifier string) (*application.TokenInfo, error) {
+	return f.token, f.tokenErr
 }
-
-func (m *MockAuthService) Logout(ctx context.Context, sessionID string) error {
-	args := m.Called(ctx, sessionID)
-	return args.Error(0)
+func (f *fakeOAuthAdapter) GetUserInfo(accessToken string) (*application.UserInfo, error) {
+	return f.user, f.userErr
 }
-
-type MockAuthzService struct {
-	mock.Mock
-}
-
-type MockOAuthAdapter struct {
-	mock.Mock
-}
-
-func (m *MockOAuthAdapter) GetUserInfo(accessToken string) (*domain.User, error) {
-	args := m.Called(accessToken)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*domain.User), args.Error(1)
-}
-
-func (m *MockOAuthAdapter) GenerateState() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockOAuthAdapter) BuildAuthURL(state string) string {
-	args := m.Called(state)
-	return args.String(0)
-}
-
-func (m *MockOAuthAdapter) buildAuthURLWithPKCE(state string, codeChallenge string) string {
-	args := m.Called(state, codeChallenge)
-	return args.String(0)
-}
-
-func (m *MockOAuthAdapter) ExchangeCodeForToken(code string, codeVerifier string) (*TokenInfo, error) {
-	args := m.Called(code, codeVerifier)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*TokenInfo), args.Error(1)
-}
-
-func (m *MockOAuthAdapter) BuildProviderLogoutURL(idToken string) string {
-	args := m.Called(idToken)
-	return args.String(0)
-}
-
-// MockLogger implements a simplified logging interface for testing
-type MockLogger struct {
-	mock.Mock
-}
-
-func (m *MockLogger) WithError(err error) *MockLogger {
-	return m
-}
-
-func (m *MockLogger) WithRequest(requestID, method, path string) *MockLogger {
-	return m
-}
-
-func (m *MockLogger) WithField(key string, value interface{}) *MockLogger {
-	return m
-}
-
-func (m *MockLogger) WithFields(fields map[string]interface{}) *MockLogger {
-	return m
-}
-
-func (m *MockLogger) Error(msg string) {
-	m.Called(msg)
-}
-
-func (m *MockLogger) Warn(msg string) {
-	m.Called(msg)
-}
-
-func (m *MockLogger) Debug(msg string) {
-	m.Called(msg)
-}
-
-func (m *MockLogger) Info(msg string) {
-	m.Called(msg)
-}
-
-func (m *MockLogger) Infof(format string, args ...interface{}) {
-	m.Called(format, args)
-}
-
-// Test fixtures
-func createTestUser(role domain.UserRole, groups []domain.UserGroup) *domain.User {
-	return &domain.User{
-		UserID: "test-user",
-		Email:  "test@example.com",
-		Role:   role,
-		Groups: groups,
-	}
-}
-
-func createTestSession(user *domain.User) *domain.Session {
-	return &domain.Session{
-		SessionID: "test-session-id",
-		User:      user,
-		IDToken:   "test-id-token",
-	}
-}
-
-// Helper function to create a user that satisfies IsAdmin() method
-func createAdminUser() *domain.User {
-	return &domain.User{
-		UserID: "admin-user",
-		Email:  "admin@example.com",
-		Role:   domain.RoleAdmin,
-		Groups: nil,
-	}
-}
-
-// Helper function to create a user that satisfies IsTeamManager() method
-func createManagerUser() *domain.User {
-	return &domain.User{
-		UserID: "manager-user",
-		Email:  "manager@example.com",
-		Role:   domain.RoleAdmin,
-		Groups: nil,
-	}
-}
-
-func setupTestRouter() *gin.Engine {
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	return router
-}
-
-// TestAuthMiddlewareAdapter wraps AuthMiddlewareAdapter for testing
-type TestAuthMiddlewareAdapter struct {
-	authService  *MockAuthService
-	authzService *MockAuthzService
-	oauthAdapter *MockOAuthAdapter
-	config       *config.AuthConfig
-	logger       *logging.Logger
-}
-
-// RequireAuth delegates to the mock for testing
-func (t *TestAuthMiddlewareAdapter) RequireAuth() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if !t.config.Enabled || !t.config.OAuth.Enabled {
-			c.Next()
-			return
-		}
-
-		var sessionID string
-
-		// 1. Try to get token from Authorization header
-		authHeader := c.GetHeader("Authorization")
-
-		if strings.HasPrefix(authHeader, "Bearer ") {
-			accessToken := strings.TrimPrefix(authHeader, "Bearer ")
-
-			// Get user info
-			userInfo, err := t.oauthAdapter.GetUserInfo(accessToken)
-			if err != nil {
-				c.JSON(400, gin.H{"error": "Failed to get user information due to: " + err.Error()})
-				return
-			}
-
-			tokenInfo := TokenInfo{AccessToken: accessToken}
-
-			//Authenticate user
-			result, err := t.authService.AuthenticateWithOAuth(
-				c.Request.Context(),
-				*userInfo,
-				tokenInfo,
-				c.ClientIP(),
-				c.GetHeader("User-Agent"),
-			)
-			if err != nil {
-				c.JSON(500, gin.H{"error": "Authentication failed"})
-				return
-			}
-			sessionID = result.Session.SessionID
-		}
-
-		// 2. If not in header, try cookie
-		if sessionID == "" {
-			cookie, err := c.Cookie("session_id")
-			if err != nil || cookie == "" {
-				t.handleUnauthenticated(c)
-				return
-			}
-			sessionID = cookie
-		}
-
-		session, err := t.authService.ValidateSession(c.Request.Context(), sessionID)
-		if err != nil {
-			t.handleUnauthenticated(c)
-			return
-		}
-
-		// Set user context
-		t.setUserContext(c, session.User, session)
-		c.Next()
-	}
-}
-
-// RequireAdmin delegates to mock for testing
-func (t *TestAuthMiddlewareAdapter) RequireAdmin() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// First ensure user is authenticated
-		t.RequireAuth()(c)
-		if c.IsAborted() {
-			return
-		}
-
-		user, exists := t.getUserFromContext(c)
-		if !exists || !user.IsAdmin() {
-			if t.isAPIRequest(c) {
-				c.JSON(403, gin.H{"error": "Admin privileges required"})
-			} else {
-				c.JSON(403, gin.H{"error": "Access denied - admin privileges required"})
-			}
-			c.Abort()
-			return
-		}
-
-		c.Next()
-	}
-}
-
-// RequireManager delegates to mock for testing
-func (t *TestAuthMiddlewareAdapter) RequireManager() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		// First ensure user is authenticated
-		t.RequireAuth()(c)
-		if c.IsAborted() {
-			return
-		}
-
-		user, exists := t.getUserFromContext(c)
-		if !exists || !user.IsTeamManager() {
-			if t.isAPIRequest(c) {
-				c.JSON(403, gin.H{"error": "Manager privileges required"})
-			} else {
-				c.JSON(403, gin.H{"error": "Access denied - manager privileges required"})
-			}
-			c.Abort()
-			return
-		}
-
-		c.Next()
-	}
-}
-
-// StartOAuthFlow for testing
-func (t *TestAuthMiddlewareAdapter) StartOAuthFlow() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if !t.config.OAuth.Enabled {
-			c.JSON(400, gin.H{"error": "OAuth not enabled"})
-			return
-		}
-
-		// Generate state parameter for security
-		state, err := t.oauthAdapter.GenerateState()
-		if err != nil {
-			c.JSON(500, gin.H{"error": "Failed to start authentication"})
-			return
-		}
-
-		// Store state in session/cookie for validation
-		isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
-		c.SetCookie("oauth_state", state, 600, "/", "", isSecure, true) // 10 minutes
-
-		authURL := ""
-		if t.config.OAuth.ClientSecret == "" {
-			// PKCE Auth Flow
-			codeVerifier, err := generateCodeVerifier()
-			if err != nil {
-				c.JSON(500, gin.H{"error": "Failed to generate PKCE verifier"})
-				return
-			}
-			codeChallenge := generateCodeChallenge(codeVerifier)
-
-			// Store pkce_verifier in session/cookie for validation
-			c.SetCookie("pkce_verifier", codeVerifier, 600, "/", "", isSecure, true)
-
-			// Build auth URL with PKCE parameters
-			authURL = t.oauthAdapter.buildAuthURLWithPKCE(state, codeChallenge)
-		} else {
-			// Build authorization URL
-			authURL = t.oauthAdapter.BuildAuthURL(state)
-		}
-
-		c.Redirect(302, authURL)
-	}
-}
-
-// HandleOAuthCallback for testing
-func (t *TestAuthMiddlewareAdapter) HandleOAuthCallback() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if !t.config.OAuth.Enabled {
-			c.JSON(400, gin.H{"error": "OAuth not enabled"})
-			return
-		}
-
-		// Validate state parameter
-		state := c.Query("state")
-		expectedState, err := c.Cookie("oauth_state")
-		if err != nil || state != expectedState {
-			c.JSON(400, gin.H{"error": "Invalid state parameter"})
-			return
-		}
-
-		// Get authorization code
-		code := c.Query("code")
-		if code == "" {
-			c.JSON(400, gin.H{"error": "Authorization code required"})
-			return
-		}
-
-		// Get code_verifier from cookie - this will dictate if we are using PKCE
-		codeVerifier, _ := c.Cookie("pkce_verifier")
-
-		// Exchange code for token
-		tokenInfo, err := t.oauthAdapter.ExchangeCodeForToken(code, codeVerifier)
-		if err != nil {
-			c.JSON(400, gin.H{"error": "Token exchange failed"})
-			return
-		}
-
-		// Get user info
-		userInfo, err := t.oauthAdapter.GetUserInfo(tokenInfo.AccessToken)
-		if err != nil {
-			c.JSON(400, gin.H{"error": "Failed to get user information"})
-			return
-		}
-
-		// Authenticate user
-		result, err := t.authService.AuthenticateWithOAuth(
-			c.Request.Context(),
-			*userInfo,
-			*tokenInfo,
-			c.ClientIP(),
-			c.GetHeader("User-Agent"),
-		)
-		if err != nil {
-			c.JSON(500, gin.H{"error": "Authentication failed"})
-			return
-		}
-
-		// Set session cookie
-		t.setSessionCookie(c, result.Session.SessionID)
-
-		// Clear state cookie
-		isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
-		c.SetCookie("oauth_state", "", -1, "/", "", isSecure, true)
-
-		// Redirect to dashboard or intended page
-		redirectURL := c.DefaultQuery("redirect", "/")
-		c.Redirect(http.StatusFound, redirectURL)
-	}
-}
-
-// Logout for testing
-func (t *TestAuthMiddlewareAdapter) Logout() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		sessionID, err := c.Cookie("session_id")
-		if err == nil && sessionID != "" {
-			// Get session for ID token
-			session, _ := t.authService.ValidateSession(c.Request.Context(), sessionID)
-
-			// Invalidate session
-			t.authService.Logout(c.Request.Context(), sessionID)
-
-			// Clear session cookie
-			isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
-			c.SetCookie("session_id", "", -1, "/", "", isSecure, true)
-
-			// Build provider logout URL
-			var providerLogoutURL string
-			if session != nil {
-				providerLogoutURL = t.oauthAdapter.BuildProviderLogoutURL(session.IDToken)
-			} else {
-				providerLogoutURL = t.oauthAdapter.BuildProviderLogoutURL("")
-			}
-
-			// For AJAX requests, return JSON response
-			if c.GetHeader("Content-Type") == "application/json" || c.GetHeader("X-Requested-With") == "XMLHttpRequest" {
-				c.JSON(200, gin.H{
-					"message":    "Logged out successfully",
-					"logout_url": providerLogoutURL,
-				})
-				return
-			}
-
-			// For direct requests, redirect to provider logout
-			c.Redirect(302, providerLogoutURL)
-			return
-		}
-
-		// No session to logout
-		c.Redirect(302, "/auth/login")
-	}
-}
-
-// Helper methods for TestAuthMiddlewareAdapter
-func (t *TestAuthMiddlewareAdapter) handleUnauthenticated(c *gin.Context) {
-	// Redirect to login for browser requests, return 401 for API requests
-	if t.isAPIRequest(c) {
-		c.JSON(401, gin.H{"error": "Authentication required"})
-	} else {
-		c.Redirect(302, "/auth/login")
-	}
-	c.Abort()
-}
-
-func (t *TestAuthMiddlewareAdapter) isAPIRequest(c *gin.Context) bool {
-	return strings.HasPrefix(c.Request.URL.Path, "/api/") ||
-		strings.Contains(c.GetHeader("Accept"), "application/json") ||
-		strings.Contains(c.GetHeader("Content-Type"), "application/json")
-}
-
-func (t *TestAuthMiddlewareAdapter) setUserContext(c *gin.Context, user *domain.User, session *domain.Session) {
-	c.Set("user", user)
-	c.Set("user_id", user.UserID)
-	c.Set("user_role", string(user.Role))
-	c.Set("session", session)
-}
-
-func (t *TestAuthMiddlewareAdapter) getUserFromContext(c *gin.Context) (*domain.User, bool) {
-	user, exists := c.Get("user")
-	if !exists {
-		return nil, false
-	}
-
-	u, ok := user.(*domain.User)
-	return u, ok
-}
-
-func (t *TestAuthMiddlewareAdapter) setSessionCookie(c *gin.Context, sessionID string) {
-	// Set secure cookie for 24 hours
-	isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
-	c.SetCookie("session_id", sessionID, 86400, "/", "", isSecure, true)
-}
-
-func createTestAdapter(authService *MockAuthService, authzService *MockAuthzService, oauthAdapter *MockOAuthAdapter, authConfig *config.AuthConfig) *TestAuthMiddlewareAdapter {
-	// Create a real logger instance for the adapter since the constructor expects *logging.Logger
-	logger := &logging.Logger{} // This should work if logging.Logger has a zero-value constructor
-
-	return &TestAuthMiddlewareAdapter{
-		authService:  authService,
-		authzService: authzService,
-		oauthAdapter: oauthAdapter,
-		config:       authConfig,
-		logger:       logger,
-	}
-}
-
-func TestNewAuthMiddlewareAdapter(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{}
-	logger := &logging.Logger{}
-
-	adapter := &TestAuthMiddlewareAdapter{
-		authService:  authService,
-		authzService: authzService,
-		oauthAdapter: oauthAdapter,
-		config:       authConfig,
-		logger:       logger,
-	}
-
-	assert.NotNil(t, adapter)
-	assert.Equal(t, authService, adapter.authService)
-	assert.Equal(t, authzService, adapter.authzService)
-	assert.Equal(t, oauthAdapter, adapter.oauthAdapter)
-	assert.Equal(t, authConfig, adapter.config)
-	assert.Equal(t, logger, adapter.logger)
-}
-
-func TestRequireAuth_AuthDisabled(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: false,
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestRequireAuth_OAuthDisabled(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: false,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-}
-
-func TestRequireAuth_BearerToken_Success(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	user := createTestUser(domain.RoleUser, nil)
-	session := createTestSession(user)
-	userInfo := &domain.User{Email: "test@example.com"}
-	authResult := &application.AuthenticateResult{
-		User:      user,
-		Session:   session,
-		IsNewUser: false,
-	}
-
-	oauthAdapter.On("GetUserInfo", "test-token").Return(userInfo, nil)
-	authService.On("AuthenticateWithOAuth", mock.Anything, *userInfo, mock.AnythingOfType("TokenInfo"), mock.Anything, mock.Anything).Return(authResult, nil)
-	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		user, exists := GetAuthUser(c)
-		assert.True(t, exists)
-		assert.Equal(t, "test-user", user.UserID)
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "Bearer test-token")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	oauthAdapter.AssertExpectations(t)
-	authService.AssertExpectations(t)
-}
-
-func TestRequireAuth_BearerToken_GetUserInfoFails(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	oauthAdapter.On("GetUserInfo", "test-token").Return(nil, errors.New("token invalid"))
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "Bearer test-token")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	oauthAdapter.AssertExpectations(t)
-}
-
-func TestRequireAuth_Cookie_Success(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	user := createTestUser(domain.RoleUser, nil)
-	session := createTestSession(user)
-
-	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		user, exists := GetAuthUser(c)
-		assert.True(t, exists)
-		assert.Equal(t, "test-user", user.UserID)
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	authService.AssertExpectations(t)
-}
-
-func TestRequireAuth_NoSessionCookie_API(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/api/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/api/test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
-
-	var response map[string]string
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	assert.Equal(t, "Authentication required", response["error"])
-}
-
-func TestRequireAuth_NoSessionCookie_Web(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "/auth/login", w.Header().Get("Location"))
-}
-
-func TestRequireAuth_InvalidSession(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	authService.On("ValidateSession", mock.Anything, "invalid-session").Return(nil, errors.New("session not found"))
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
-	})
-
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: "invalid-session"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "/auth/login", w.Header().Get("Location"))
-	authService.AssertExpectations(t)
-}
-
-func TestRequireAdmin_Success(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	adminUser := createAdminUser()
-	session := createTestSession(adminUser)
-
-	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAdmin())
-	router.GET("/admin/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "admin success"})
-	})
-
-	req := httptest.NewRequest("GET", "/admin/test", nil)
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	authService.AssertExpectations(t)
-}
-
-func TestRequireManager_Success(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	managerUser := createManagerUser()
-	session := createTestSession(managerUser)
-
-	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireManager())
-	router.GET("/manager/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "manager success"})
-	})
-
-	req := httptest.NewRequest("GET", "/manager/test", nil)
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	authService.AssertExpectations(t)
-}
-
-func TestStartOAuthFlow_OAuthDisabled(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled: false,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.GET("/auth/login", adapter.StartOAuthFlow())
-
-	req := httptest.NewRequest("GET", "/auth/login", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-}
-
-func TestStartOAuthFlow_WithClientSecret(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled:      true,
-			ClientSecret: "test-secret",
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	oauthAdapter.On("GenerateState").Return("test-state", nil)
-	oauthAdapter.On("BuildAuthURL", "test-state").Return("https://provider.com/auth?state=test-state")
-
-	router := setupTestRouter()
-	router.GET("/auth/login", adapter.StartOAuthFlow())
-
-	req := httptest.NewRequest("GET", "/auth/login", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "https://provider.com/auth?state=test-state", w.Header().Get("Location"))
-
-	// Check that oauth_state cookie was set
-	cookies := w.Header()["Set-Cookie"]
-	found := false
-	for _, cookie := range cookies {
-		if strings.Contains(cookie, "oauth_state=test-state") {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "oauth_state cookie should be set")
-
-	oauthAdapter.AssertExpectations(t)
-}
-
-func TestStartOAuthFlow_PKCE(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled:      true,
-			ClientSecret: "", // Empty triggers PKCE flow
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	oauthAdapter.On("GenerateState").Return("test-state", nil)
-	oauthAdapter.On("buildAuthURLWithPKCE", "test-state", mock.AnythingOfType("string")).Return("https://provider.com/auth?state=test-state&code_challenge=challenge")
-
-	router := setupTestRouter()
-	router.GET("/auth/login", adapter.StartOAuthFlow())
-
-	req := httptest.NewRequest("GET", "/auth/login", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "https://provider.com/auth?state=test-state&code_challenge=challenge", w.Header().Get("Location"))
-
-	// Check that both oauth_state and pkce_verifier cookies were set
-	cookies := w.Header()["Set-Cookie"]
-	stateFound := false
-	verifierFound := false
-	for _, cookie := range cookies {
-		if strings.Contains(cookie, "oauth_state=test-state") {
-			stateFound = true
-		}
-		if strings.Contains(cookie, "pkce_verifier=") {
-			verifierFound = true
-		}
-	}
-	assert.True(t, stateFound, "oauth_state cookie should be set")
-	assert.True(t, verifierFound, "pkce_verifier cookie should be set")
-
-	oauthAdapter.AssertExpectations(t)
-}
-
-func TestHandleOAuthCallback_Success(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	user := createTestUser(domain.RoleUser, nil)
-	session := createTestSession(user)
-	userInfo := &domain.User{Email: "test@example.com"}
-	tokenInfo := &TokenInfo{AccessToken: "access-token"}
-	authResult := &application.AuthenticateResult{
-		User:      user,
-		Session:   session,
-		IsNewUser: false,
-	}
-
-	oauthAdapter.On("ExchangeCodeForToken", "auth-code", "").Return(tokenInfo, nil)
-	oauthAdapter.On("GetUserInfo", "access-token").Return(userInfo, nil)
-	authService.On("AuthenticateWithOAuth", mock.Anything, *userInfo, *tokenInfo, mock.Anything, mock.Anything).Return(authResult, nil)
-
-	router := setupTestRouter()
-	router.GET("/auth/callback", adapter.HandleOAuthCallback())
-
-	req := httptest.NewRequest("GET", "/auth/callback?code=auth-code&state=test-state", nil)
-	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "/", w.Header().Get("Location"))
-
-	// Check that session_id cookie was set
-	cookies := w.Header()["Set-Cookie"]
-	sessionFound := false
-	for _, cookie := range cookies {
-		if strings.Contains(cookie, "session_id=test-session-id") {
-			sessionFound = true
-			break
-		}
-	}
-	assert.True(t, sessionFound, "session_id cookie should be set")
-
-	oauthAdapter.AssertExpectations(t)
-	authService.AssertExpectations(t)
-}
-
-func TestHandleOAuthCallback_InvalidState(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.GET("/auth/callback", adapter.HandleOAuthCallback())
-
-	req := httptest.NewRequest("GET", "/auth/callback?code=auth-code&state=wrong-state", nil)
-	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-
-	var response map[string]string
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	assert.Equal(t, "Invalid state parameter", response["error"])
-}
-
-func TestLogout_Success(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	user := createTestUser(domain.RoleUser, nil)
-	session := createTestSession(user)
-
-	authService.On("ValidateSession", mock.Anything, "test-session-id").Return(session, nil)
-	authService.On("Logout", mock.Anything, "test-session-id").Return(nil)
-	oauthAdapter.On("BuildProviderLogoutURL", "test-id-token").Return("https://provider.com/logout")
-
-	router := setupTestRouter()
-	router.GET("/auth/logout", adapter.Logout())
-
-	req := httptest.NewRequest("GET", "/auth/logout", nil)
-	req.AddCookie(&http.Cookie{Name: "session_id", Value: "test-session-id"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "https://provider.com/logout", w.Header().Get("Location"))
-
-	authService.AssertExpectations(t)
-	oauthAdapter.AssertExpectations(t)
-}
-
-func TestLogout_NoSession(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	router := setupTestRouter()
-	router.GET("/auth/logout", adapter.Logout())
-
-	req := httptest.NewRequest("GET", "/auth/logout", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, "/auth/login", w.Header().Get("Location"))
-}
-
-func TestIsAPIRequest(t *testing.T) {
-	adapter := &AuthMiddlewareAdapter{}
-
-	tests := []struct {
-		name     string
-		path     string
-		headers  map[string]string
-		expected bool
-	}{
-		{
-			name:     "API path",
-			path:     "/api/users",
-			expected: true,
-		},
-		{
-			name:     "JSON Accept header",
-			path:     "/users",
-			headers:  map[string]string{"Accept": "application/json"},
-			expected: true,
-		},
-		{
-			name:     "JSON Content-Type header",
-			path:     "/users",
-			headers:  map[string]string{"Content-Type": "application/json"},
-			expected: true,
-		},
-		{
-			name:     "Regular web request",
-			path:     "/users",
-			headers:  map[string]string{"Accept": "text/html"},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c, _ := gin.CreateTestContext(httptest.NewRecorder())
-			c.Request = httptest.NewRequest("GET", tt.path, nil)
-
-			for key, value := range tt.headers {
-				c.Request.Header.Set(key, value)
-			}
-
-			result := adapter.isAPIRequest(c)
-			assert.Equal(t, tt.expected, result)
+func (f *fakeOAuthAdapter) BuildProviderLogoutURL(idToken string) string { return f.logoutURL }
+
+var _ = Describe("AuthMiddlewareAdapter", Label("auth"), func() {
+	var (
+		authSvc  *fakeAuthService
+		oauth    *fakeOAuthAdapter
+		cfg      *config.AuthConfig
+		logger   *logging.Logger
+		adapter  *interfaces.AuthMiddlewareAdapter
+		recorder *httptest.ResponseRecorder
+		c        *gin.Context
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		authSvc = &fakeAuthService{}
+		oauth = &fakeOAuthAdapter{state: "state123", authURL: "http://auth", logoutURL: "http://logout"}
+		cfg = &config.AuthConfig{Enabled: true, OAuth: config.OAuthConfig{Enabled: true}}
+		logger, _ = logging.NewLogger(&config.LoggingConfig{
+			Level: "debug",
 		})
-	}
-}
-
-func TestGetAuthUser(t *testing.T) {
-	user := createTestUser(domain.RoleUser, nil)
-
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("user", user)
-
-	retrievedUser, exists := GetAuthUser(c)
-	assert.True(t, exists)
-	assert.Equal(t, user, retrievedUser)
-
-	// Test when user doesn't exist
-	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
-	retrievedUser2, exists2 := GetAuthUser(c2)
-	assert.False(t, exists2)
-	assert.Nil(t, retrievedUser2)
-}
-
-func TestGetAuthSession(t *testing.T) {
-	user := createTestUser(domain.RoleUser, nil)
-	session := createTestSession(user)
-
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("session", session)
-
-	retrievedSession, exists := GetAuthSession(c)
-	assert.True(t, exists)
-	assert.Equal(t, session, retrievedSession)
-
-	// Test when session doesn't exist
-	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
-	retrievedSession2, exists2 := GetAuthSession(c2)
-	assert.False(t, exists2)
-	assert.Nil(t, retrievedSession2)
-}
-
-func TestIsAdmin(t *testing.T) {
-	// Test with admin user
-	adminUser := createAdminUser()
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("user", adminUser)
-
-	assert.True(t, IsAdmin(c))
-
-	// Test with non-admin user
-	regularUser := createTestUser(domain.RoleUser, nil)
-	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c2.Set("user", regularUser)
-
-	assert.False(t, IsAdmin(c2))
-
-	// Test with no user
-	c3, _ := gin.CreateTestContext(httptest.NewRecorder())
-	assert.False(t, IsAdmin(c3))
-}
-
-func TestIsTeamManager(t *testing.T) {
-	// Test with manager user
-	managerUser := createManagerUser()
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("user", managerUser)
-
-	assert.True(t, IsTeamManager(c))
-
-	// Test with non-manager user
-	regularUser := createTestUser(domain.RoleUser, nil)
-	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c2.Set("user", regularUser)
-
-	assert.False(t, IsTeamManager(c2))
-
-	// Test with no user
-	c3, _ := gin.CreateTestContext(httptest.NewRecorder())
-	assert.False(t, IsTeamManager(c3))
-}
-
-func TestIsManagerForTeam(t *testing.T) {
-	// Create user with team-specific manager group
-	groups := []domain.UserGroup{
-		{GroupName: "team1-managers"},
-		{GroupName: "team2-users"},
-	}
-	user := createTestUser(domain.RoleUser, groups)
-
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("user", user)
-
-	assert.True(t, IsManagerForTeam(c, "team1"))
-	assert.False(t, IsManagerForTeam(c, "team2"))
-	assert.False(t, IsManagerForTeam(c, "team3"))
-
-	// Test with no user
-	c2, _ := gin.CreateTestContext(httptest.NewRecorder())
-	assert.False(t, IsManagerForTeam(c2, "team1"))
-}
-
-func TestCanAccessTeamProjects(t *testing.T) {
-	tests := []struct {
-		name     string
-		role     domain.UserRole
-		groups   []domain.UserGroup
-		team     string
-		expected bool
-	}{
-		{
-			name:     "Admin can access any team",
-			role:     domain.RoleAdmin,
-			groups:   nil,
-			team:     "anyteam",
-			expected: true,
-		},
-		{
-			name: "User with manager group can access team",
-			role: domain.RoleUser,
-			groups: []domain.UserGroup{
-				{GroupName: "team1-managers"},
-			},
-			team:     "team1",
-			expected: true,
-		},
-		{
-			name: "User with user group can access team",
-			role: domain.RoleUser,
-			groups: []domain.UserGroup{
-				{GroupName: "team1-users"},
-			},
-			team:     "team1",
-			expected: true,
-		},
-		{
-			name: "User with slash prefix group can access team",
-			role: domain.RoleUser,
-			groups: []domain.UserGroup{
-				{GroupName: "/team1-users"},
-			},
-			team:     "team1",
-			expected: true,
-		},
-		{
-			name: "User without team group cannot access team",
-			role: domain.RoleUser,
-			groups: []domain.UserGroup{
-				{GroupName: "team2-users"},
-			},
-			team:     "team1",
-			expected: false,
-		},
-		{
-			name:     "User with no groups cannot access team",
-			role:     domain.RoleUser,
-			groups:   nil,
-			team:     "team1",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var user *domain.User
-			if tt.role == domain.RoleAdmin {
-				user = createAdminUser()
-				user.Groups = tt.groups
-			} else {
-				user = createTestUser(tt.role, tt.groups)
-			}
-
-			c, _ := gin.CreateTestContext(httptest.NewRecorder())
-			c.Set("user", user)
-
-			result := CanAccessTeamProjects(c, tt.team)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-
-	// Test with no user
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	assert.False(t, CanAccessTeamProjects(c, "team1"))
-}
-
-func TestGenerateCodeVerifier(t *testing.T) {
-	verifier, err := generateCodeVerifier()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, verifier)
-
-	// Verify it's base64url encoded
-	decoded, err := base64.RawURLEncoding.DecodeString(verifier)
-	assert.NoError(t, err)
-	assert.Len(t, decoded, 32) // Should be 32 bytes
-}
-
-func TestGenerateCodeChallenge(t *testing.T) {
-	verifier := "test-verifier-string"
-	challenge := generateCodeChallenge(verifier)
-
-	assert.NotEmpty(t, challenge)
-
-	// Verify it's base64url encoded
-	_, err := base64.RawURLEncoding.DecodeString(challenge)
-	assert.NoError(t, err)
-
-	// Should be deterministic
-	challenge2 := generateCodeChallenge(verifier)
-	assert.Equal(t, challenge, challenge2)
-}
-
-func TestSetUserContext(t *testing.T) {
-	adapter := &TestAuthMiddlewareAdapter{}
-	user := createTestUser(domain.RoleUser, nil)
-	session := createTestSession(user)
-
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	adapter.setUserContext(c, user, session)
-
-	// Verify all context values are set correctly
-	contextUser, exists := c.Get("user")
-	assert.True(t, exists)
-	assert.Equal(t, user, contextUser)
-
-	userID, exists := c.Get("user_id")
-	assert.True(t, exists)
-	assert.Equal(t, "test-user", userID)
-
-	userRole, exists := c.Get("user_role")
-	assert.True(t, exists)
-	assert.Equal(t, string(domain.RoleUser), userRole)
-
-	contextSession, exists := c.Get("session")
-	assert.True(t, exists)
-	assert.Equal(t, session, contextSession)
-}
-
-func TestSetSessionCookie(t *testing.T) {
-	adapter := &AuthMiddlewareAdapter{}
-
-	// Create test context and recorder
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("GET", "/", nil)
-
-	adapter.setSessionCookie(c, "test-session-id")
-
-	// Check that the cookie was set in the response
-	cookies := w.Header()["Set-Cookie"]
-
-	found := false
-	for _, cookie := range cookies {
-		if strings.Contains(cookie, "session_id=test-session-id") {
-			found = true
-			// Verify cookie properties
-			assert.Contains(t, cookie, "HttpOnly")
-			assert.Contains(t, cookie, "Path=/")
-			assert.Contains(t, cookie, "Max-Age=86400")
-			break
-		}
-	}
-	assert.True(t, found, "session_id cookie should be set")
-}
-
-func TestRequireAuth_AuthenticationFails(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		Enabled: true,
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
-
-	userInfo := &domain.User{Email: "test@example.com"}
-	oauthAdapter.On("GetUserInfo", "test-token").Return(userInfo, nil)
-	authService.On("AuthenticateWithOAuth", mock.Anything, *userInfo, mock.AnythingOfType("TokenInfo"), mock.Anything, mock.Anything).Return(nil, errors.New("authentication failed"))
-
-	router := setupTestRouter()
-	router.Use(adapter.RequireAuth())
-	router.GET("/test", func(c *gin.Context) {
-		c.JSON(200, gin.H{"message": "success"})
+		adapter = interfaces.NewAuthMiddlewareAdapter(authSvc, nil, oauth, cfg, logger)
+		recorder = httptest.NewRecorder()
+		c, _ = gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest("GET", "/", nil)
 	})
 
-	req := httptest.NewRequest("GET", "/test", nil)
-	req.Header.Set("Authorization", "Bearer test-token")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+	Describe("GenerateCodeVerifier/Challenge", func() {
+		It("generates verifier and challenge", func() {
+			verifier, err := interfaces.GenerateCodeVerifier()
+			Expect(err).To(BeNil())
+			Expect(len(verifier)).To(BeNumerically(">", 10))
 
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+			challenge := interfaces.GenerateCodeChallenge(verifier)
+			h := sha256.Sum256([]byte(verifier))
+			Expect(challenge).To(Equal(base64.RawURLEncoding.EncodeToString(h[:])))
+		})
+	})
 
-	// Debug what we actually got
-	responseBody := w.Body.String()
-	t.Logf("Actual response body: %q", responseBody)
+	Describe("RequireAuth", func() {
+		It("authenticates with bearer token", func() {
+			oauth.user = &application.UserInfo{Sub: "u1"}
+			authSvc.authFn = func(ctx context.Context, u application.UserInfo, t application.TokenInfo, ip, ua string) (*application.AuthenticateResult, error) {
+				return &application.AuthenticateResult{Session: &domain.Session{SessionID: "sid1"}, User: &domain.User{UserID: "u1"}}, nil
+			}
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) {
+				return &domain.Session{SessionID: sid, User: &domain.User{UserID: "u1"}}, nil
+			}
 
-	// Try to extract just the first JSON object if there are multiples
-	var response map[string]string
-	decoder := json.NewDecoder(strings.NewReader(responseBody))
-	err := decoder.Decode(&response)
-	require.NoError(t, err)
-	assert.Equal(t, "Authentication failed", response["error"])
+			c.Request.Header.Set("Authorization", "Bearer abc")
+			mw := adapter.RequireAuth()
+			mw(c)
 
-	oauthAdapter.AssertExpectations(t)
-	authService.AssertExpectations(t)
-}
+			Expect(c.IsAborted()).To(BeFalse())
+			Expect(c.Keys["user_id"]).To(Equal("u1"))
+		})
 
-func TestHandleOAuthCallback_MissingCode(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+		It("fails with invalid token", func() {
+			oauth.userErr = errors.New("bad token")
+			c.Request.Header.Set("Authorization", "Bearer bad")
+			mw := adapter.RequireAuth()
+			mw(c)
 
-	router := setupTestRouter()
-	router.GET("/auth/callback", adapter.HandleOAuthCallback())
+			Expect(recorder.Code).To(Equal(400))
+		})
 
-	req := httptest.NewRequest("GET", "/auth/callback?state=test-state", nil)
-	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+		It("redirects to login if no session", func() {
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) { return nil, errors.New("bad session") }
+			mw := adapter.RequireAuth()
+			mw(c)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+			Expect(recorder.Code).To(Equal(302))
+			Expect(recorder.Header().Get("Location")).To(Equal("/auth/login"))
+		})
+	})
 
-	var response map[string]string
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	assert.Equal(t, "Authorization code required", response["error"])
-}
+	Describe("StartOAuthFlow", func() {
+		It("redirects with PKCE flow when no client secret", func() {
+			cfg.OAuth.ClientSecret = ""
+			mw := adapter.StartOAuthFlow()
+			mw(c)
 
-func TestHandleOAuthCallback_TokenExchangeFails(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+			Expect(recorder.Code).To(Equal(302))
+			Expect(recorder.Header().Get("Location")).To(ContainSubstring("http://auth"))
+		})
 
-	oauthAdapter.On("ExchangeCodeForToken", "auth-code", "").Return(nil, errors.New("token exchange failed"))
+		It("returns error if state generation fails", func() {
+			oauth.stateErr = errors.New("fail")
+			mw := adapter.StartOAuthFlow()
+			mw(c)
+			Expect(recorder.Code).To(Equal(500))
+		})
+	})
 
-	router := setupTestRouter()
-	router.GET("/auth/callback", adapter.HandleOAuthCallback())
+	Describe("HandleOAuthCallback", func() {
+		BeforeEach(func() {
+			c.Request = httptest.NewRequest("GET", "/callback?state=state123&code=abc", nil)
+			c.SetCookie("oauth_state", "state123", 600, "/", "", false, true)
+		})
 
-	req := httptest.NewRequest("GET", "/auth/callback?code=auth-code&state=test-state", nil)
-	req.AddCookie(&http.Cookie{Name: "oauth_state", Value: "test-state"})
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+		It("completes happy path", func() {
+			// attach cookie to *incoming request*
+			req := httptest.NewRequest("GET", "/callback?state=state123&code=abc", nil)
+			req.AddCookie(&http.Cookie{
+				Name:  "oauth_state",
+				Value: "state123",
+			})
+			c.Request = req
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+			oauth.token = &application.TokenInfo{AccessToken: "tok"}
+			oauth.user = &application.UserInfo{Sub: "u1"}
+			authSvc.authFn = func(ctx context.Context, u application.UserInfo, t application.TokenInfo, ip, ua string) (*application.AuthenticateResult, error) {
+				return &application.AuthenticateResult{
+					Session: &domain.Session{SessionID: "s1"},
+					User:    &domain.User{UserID: "u1"},
+				}, nil
+			}
 
-	var response map[string]string
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	assert.Equal(t, "Token exchange failed", response["error"])
+			mw := adapter.HandleOAuthCallback()
+			mw(c)
 
-	oauthAdapter.AssertExpectations(t)
-}
+			Expect(recorder.Code).To(Equal(302))
+			Expect(recorder.Header().Get("Location")).To(Equal("/"))
+		})
 
-func TestStartOAuthFlow_StateGenerationFails(t *testing.T) {
-	authService := &MockAuthService{}
-	authzService := &MockAuthzService{}
-	oauthAdapter := &MockOAuthAdapter{}
-	authConfig := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled: true,
-		},
-	}
-	adapter := createTestAdapter(authService, authzService, oauthAdapter, authConfig)
+		It("fails with invalid state", func() {
+			c.Request = httptest.NewRequest("GET", "/callback?state=wrong", nil)
+			mw := adapter.HandleOAuthCallback()
+			mw(c)
+			Expect(recorder.Code).To(Equal(400))
+		})
 
-	oauthAdapter.On("GenerateState").Return("", errors.New("state generation failed"))
+		It("fails with missing code", func() {
+			c.Request = httptest.NewRequest("GET", "/callback?state=state123", nil)
+			c.SetCookie("oauth_state", "state123", 600, "/", "", false, true)
+			mw := adapter.HandleOAuthCallback()
+			mw(c)
+			Expect(recorder.Code).To(Equal(400))
+		})
+	})
 
-	router := setupTestRouter()
-	router.GET("/auth/login", adapter.StartOAuthFlow())
+	Describe("Logout", func() {
+		It("clears session and redirects", func() {
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) {
+				return &domain.Session{SessionID: "s1", IDToken: "idtok"}, nil
+			}
+			authSvc.logoutFn = func(ctx context.Context, sid string) error { return nil }
+			c.SetCookie("session_id", "s1", 600, "/", "", false, true)
 
-	req := httptest.NewRequest("GET", "/auth/login", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+			mw := adapter.Logout()
+			mw(c)
 
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+			Expect(recorder.Code).To(Equal(302))
+			Expect(recorder.Header().Get("Location")).To(Equal("/auth/login"))
+		})
 
-	var response map[string]string
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	assert.Equal(t, "Failed to start authentication", response["error"])
+		It("redirects to login if no session", func() {
+			mw := adapter.Logout()
+			mw(c)
+			Expect(recorder.Code).To(Equal(302))
+			Expect(recorder.Header().Get("Location")).To(Equal("/auth/login"))
+		})
+	})
 
-	oauthAdapter.AssertExpectations(t)
-}
+	// New tests for extra cases
+	Describe("Logout extra cases", func() {
+		It("returns JSON for AJAX request", func() {
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) {
+				return &domain.Session{SessionID: "s1", IDToken: "idtok"}, nil
+			}
+			authSvc.logoutFn = func(ctx context.Context, sid string) error { return nil }
+
+			req := httptest.NewRequest("POST", "/logout", nil)
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "s1"})
+			req.Header.Set("X-Requested-With", "XMLHttpRequest")
+			c.Request = req
+
+			mw := adapter.Logout()
+			mw(c)
+
+			Expect(recorder.Code).To(Equal(200))
+			Expect(recorder.Body.String()).To(ContainSubstring("Logged out successfully"))
+		})
+
+		It("redirects even if ValidateSession returns nil", func() {
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) {
+				return nil, nil
+			}
+			authSvc.logoutFn = func(ctx context.Context, sid string) error { return nil }
+
+			req := httptest.NewRequest("POST", "/logout", nil)
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "s1"})
+
+			w := httptest.NewRecorder()
+			r := gin.New()
+			r.POST("/logout", adapter.Logout()) // attach middleware as route handler
+
+			r.ServeHTTP(w, req) // actually run HTTP request through Gin
+
+			Expect(w.Code).To(Equal(302))
+			Expect(w.Header().Get("Location")).To(Equal("http://logout"))
+		})
+	})
+
+	Describe("RequireAdmin", func() {
+		It("denies non-admin user", func() {
+			u := &domain.User{UserID: "u1", Role: domain.RoleUser}
+			s := &domain.Session{SessionID: "s1", User: u}
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) { return s, nil }
+
+			req := httptest.NewRequest("GET", "/api/admin", nil)
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "s1"})
+			w := httptest.NewRecorder()
+			r := gin.New()
+			r.GET("/api/admin", adapter.RequireAdmin())
+
+			r.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(403))
+			Expect(w.Body.String()).To(ContainSubstring("Admin privileges required"))
+		})
+
+		It("allows admin user", func() {
+			u := &domain.User{UserID: "admin1", Role: domain.RoleAdmin}
+			s := &domain.Session{SessionID: "s1", User: u}
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) { return s, nil }
+
+			req := httptest.NewRequest("GET", "/api/admin", nil)
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "s1"})
+
+			w := httptest.NewRecorder()
+			r := gin.New()
+			r.Use(adapter.RequireAdmin())
+			r.GET("/api/admin", func(c *gin.Context) {
+				c.String(200, "ok")
+			})
+
+			r.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(200))
+			Expect(w.Body.String()).To(Equal("ok"))
+		})
+	})
+
+	Describe("RequireManager", func() {
+		It("denies non-manager user", func() {
+			u := &domain.User{UserID: "u1", Role: domain.RoleUser}
+			s := &domain.Session{SessionID: "s1", User: u}
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) {
+				return s, nil
+			}
+
+			// Create request with session cookie
+			req := httptest.NewRequest("GET", "/api/teams", nil)
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "s1"})
+			w := httptest.NewRecorder()
+
+			// Only mount RequireManager — no final handler
+			r := gin.New()
+			r.GET("/api/teams", adapter.RequireManager())
+
+			// Run request
+			r.ServeHTTP(w, req)
+
+			// Assert response
+			Expect(w.Code).To(Equal(403))
+			Expect(w.Body.String()).To(ContainSubstring("Manager privileges required"))
+		})
+
+		It("allows manager user", func() {
+			u := &domain.User{
+				UserID: "u2",
+				Role:   domain.RoleUser, // Role doesn't matter for IsTeamManager
+				Groups: []domain.UserGroup{
+					{GroupName: "team-managers"}, // manager group
+				},
+			}
+			s := &domain.Session{SessionID: "s2", User: u}
+			authSvc.validateFn = func(ctx context.Context, sid string) (*domain.Session, error) { return s, nil }
+
+			req := httptest.NewRequest("GET", "/api/teams", nil)
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "s2"})
+			w := httptest.NewRecorder()
+
+			r := gin.New()
+			r.GET("/api/teams", adapter.RequireManager(), func(c *gin.Context) {
+				c.String(200, "ok")
+			})
+
+			r.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(200))
+			Expect(w.Body.String()).To(Equal("ok"))
+		})
+	})
+
+	// -----------------Nimish -----------------
+
+	Describe("CanAccessTeamProjects", func() {
+		var c *gin.Context
+
+		BeforeEach(func() {
+			w := httptest.NewRecorder()
+			c, _ = gin.CreateTestContext(w)
+		})
+
+		It("returns false if no user in context", func() {
+			Expect(interfaces.CanAccessTeamProjects(c, "team1")).To(BeFalse())
+		})
+
+		It("returns true if user is admin", func() {
+			u := &domain.User{
+				UserID: "admin1",
+				Role:   domain.RoleAdmin,
+			}
+			c.Set("user", u)
+			Expect(interfaces.CanAccessTeamProjects(c, "team1")).To(BeTrue())
+		})
+
+		It("returns true if user is in team-managers group", func() {
+			u := &domain.User{
+				UserID: "u1",
+				Role:   domain.RoleUser,
+				Groups: []domain.UserGroup{
+					{GroupName: "team1-managers"},
+				},
+			}
+			c.Set("user", u)
+			Expect(interfaces.CanAccessTeamProjects(c, "team1")).To(BeTrue())
+		})
+
+		It("returns true if user is in team-users group", func() {
+			u := &domain.User{
+				UserID: "u2",
+				Role:   domain.RoleUser,
+				Groups: []domain.UserGroup{
+					{GroupName: "team1-users"},
+				},
+			}
+			c.Set("user", u)
+			Expect(interfaces.CanAccessTeamProjects(c, "team1")).To(BeTrue())
+		})
+
+		It("returns false if user is not in any relevant groups", func() {
+			u := &domain.User{
+				UserID: "u3",
+				Role:   domain.RoleUser,
+				Groups: []domain.UserGroup{
+					{GroupName: "other-team-managers"},
+				},
+			}
+			c.Set("user", u)
+			Expect(interfaces.CanAccessTeamProjects(c, "team1")).To(BeFalse())
+		})
+
+		It("handles group names with leading slash", func() {
+			u := &domain.User{
+				UserID: "u4",
+				Role:   domain.RoleUser,
+				Groups: []domain.UserGroup{
+					{GroupName: "/team1-users"},
+				},
+			}
+			c.Set("user", u)
+			Expect(interfaces.CanAccessTeamProjects(c, "team1")).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("Auth Middleware Helper Functions", func() {
+	var (
+		c *gin.Context
+		w *httptest.ResponseRecorder
+		_ *gin.Engine
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		w = httptest.NewRecorder()
+		_ = gin.New()
+		c, _ = gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/test", nil)
+	})
+
+	Describe("GetAuthSession", func() {
+		Context("when session is not set in context", func() {
+			It("should return nil and false", func() {
+				session, exists := interfaces.GetAuthSession(c)
+				Expect(session).To(BeNil())
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		Context("when session is set with wrong type", func() {
+			It("should return nil and false", func() {
+				c.Set("session", "invalid-session-type")
+
+				session, exists := interfaces.GetAuthSession(c)
+				Expect(session).To(BeNil())
+				Expect(exists).To(BeFalse())
+			})
+		})
+
+		Context("when session is set with correct type", func() {
+			It("should return session and true", func() {
+				mockSession := &domain.Session{
+					SessionID: "test-session-id",
+					UserID:    "test-user-id",
+					IDToken:   "test-id-token",
+				}
+				c.Set("session", mockSession)
+
+				session, exists := interfaces.GetAuthSession(c)
+				Expect(session).To(Equal(mockSession))
+				Expect(exists).To(BeTrue())
+				Expect(session.SessionID).To(Equal("test-session-id"))
+				Expect(session.UserID).To(Equal("test-user-id"))
+				Expect(session.IDToken).To(Equal("test-id-token"))
+			})
+		})
+	})
+
+	Describe("IsTeamManager", func() {
+		Context("when user is not set in context", func() {
+			It("should return false", func() {
+				result := interfaces.IsTeamManager(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user is set with wrong type", func() {
+			It("should return false", func() {
+				c.Set("user", "invalid-user-type")
+
+				result := interfaces.IsTeamManager(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user exists but is not a team manager", func() {
+			It("should return false", func() {
+				mockUser := &domain.User{
+					UserID: "test-user",
+					Email:  "test@example.com",
+					Role:   domain.RoleUser, // Regular user role
+					Groups: []domain.UserGroup{
+						{GroupName: "regular-group"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsTeamManager(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user exists and is a team manager", func() {
+			It("should return true", func() {
+				mockUser := &domain.User{
+					UserID: "test-manager",
+					Email:  "manager@example.com",
+					Role:   domain.RoleUser,
+					Groups: []domain.UserGroup{
+						{GroupName: "team1-managers"},
+						{GroupName: "regular-group"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsTeamManager(c)
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when user is admin", func() {
+			It("should return true", func() {
+				mockUser := &domain.User{
+					UserID: "test-admin",
+					Email:  "admin@example.com",
+					Role:   domain.RoleAdmin,
+					Groups: []domain.UserGroup{},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsTeamManager(c)
+				Expect(result).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("IsAdmin", func() {
+		Context("when user is not set in context", func() {
+			It("should return false", func() {
+				result := interfaces.IsAdmin(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user is set with wrong type", func() {
+			It("should return false", func() {
+				c.Set("user", "invalid-user-type")
+
+				result := interfaces.IsAdmin(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user exists but is not an admin", func() {
+			It("should return false", func() {
+				mockUser := &domain.User{
+					UserID: "test-user",
+					Email:  "user@example.com",
+					Role:   domain.RoleUser, // Regular user role
+					Groups: []domain.UserGroup{
+						{GroupName: "regular-group"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsAdmin(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user exists and is an admin", func() {
+			It("should return true", func() {
+				mockUser := &domain.User{
+					UserID: "test-admin",
+					Email:  "admin@example.com",
+					Role:   domain.RoleAdmin, // Admin role
+					Groups: []domain.UserGroup{
+						{GroupName: "admin-group"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsAdmin(c)
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when user exists with manager role but not admin", func() {
+			It("should return false", func() {
+				mockUser := &domain.User{
+					UserID: "test-manager",
+					Email:  "manager@example.com",
+					Role:   domain.RoleUser, // User role with manager groups
+					Groups: []domain.UserGroup{
+						{GroupName: "team1-managers"},
+						{GroupName: "team2-managers"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsAdmin(c)
+				Expect(result).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("IsManagerForTeam", func() {
+		teamName := "engineering"
+
+		Context("when user is not set in context", func() {
+			It("should return false", func() {
+				result := interfaces.IsManagerForTeam(c, teamName)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user is set with wrong type", func() {
+			It("should return false", func() {
+				c.Set("user", "invalid-user-type")
+
+				result := interfaces.IsManagerForTeam(c, teamName)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user exists but is not manager for the specific team", func() {
+			It("should return false", func() {
+				mockUser := &domain.User{
+					UserID: "test-user",
+					Email:  "user@example.com",
+					Role:   domain.RoleUser,
+					Groups: []domain.UserGroup{
+						{GroupName: "other-team-managers"},
+						{GroupName: "engineering-users"}, // User of the team but not manager
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsManagerForTeam(c, teamName)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when user exists and is manager for the specific team", func() {
+			It("should return true", func() {
+				mockUser := &domain.User{
+					UserID: "test-manager",
+					Email:  "manager@example.com",
+					Role:   domain.RoleUser,
+					Groups: []domain.UserGroup{
+						{GroupName: "engineering-managers"},
+						{GroupName: "other-group"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsManagerForTeam(c, teamName)
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when user is admin", func() {
+			It("should return true regardless of team", func() {
+				mockUser := &domain.User{
+					UserID: "test-admin",
+					Email:  "admin@example.com",
+					Role:   domain.RoleAdmin,
+					Groups: []domain.UserGroup{}, // Admin doesn't need specific groups
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsManagerForTeam(c, teamName)
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		Context("when user has manager group with leading slash", func() {
+			It("should return false (domain method doesn't handle leading slash)", func() {
+				mockUser := &domain.User{
+					UserID: "test-manager",
+					Email:  "manager@example.com",
+					Role:   domain.RoleUser,
+					Groups: []domain.UserGroup{
+						{GroupName: "/engineering-managers"}, // Group with leading slash
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsManagerForTeam(c, teamName)
+				Expect(result).To(BeFalse())
+			})
+		})
+
+		Context("when checking empty team name", func() {
+			It("should return false for non-admin users", func() {
+				mockUser := &domain.User{
+					UserID: "test-user",
+					Email:  "user@example.com",
+					Role:   domain.RoleUser,
+					Groups: []domain.UserGroup{
+						{GroupName: "some-managers"},
+					},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsManagerForTeam(c, "")
+				Expect(result).To(BeFalse())
+			})
+
+			It("should return true for admin users", func() {
+				mockUser := &domain.User{
+					UserID: "test-admin",
+					Email:  "admin@example.com",
+					Role:   domain.RoleAdmin,
+					Groups: []domain.UserGroup{},
+				}
+				c.Set("user", mockUser)
+
+				result := interfaces.IsManagerForTeam(c, "")
+				Expect(result).To(BeTrue())
+			})
+		})
+	})
+})

--- a/internal/domains/auth/interfaces/oauth_adapter_test.go
+++ b/internal/domains/auth/interfaces/oauth_adapter_test.go
@@ -1,0 +1,530 @@
+package interfaces
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/guidewire-oss/fern-platform/internal/domains/auth/application"
+	"github.com/guidewire-oss/fern-platform/pkg/config"
+	"github.com/guidewire-oss/fern-platform/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestOAuthAdapter() *OAuthAdapter {
+	cfg := &config.AuthConfig{
+		OAuth: config.OAuthConfig{
+			Enabled:      true,
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			RedirectURL:  "http://localhost:8080/auth/callback",
+			AuthURL:      "https://provider.com/auth",
+			TokenURL:     "https://provider.com/token",
+			UserInfoURL:  "https://provider.com/userinfo",
+			LogoutURL:    "https://provider.com/logout",
+			IssuerURL:    "https://provider.com",
+			Scopes:       []string{"openid", "profile", "email"},
+			UserIDField:  "sub",
+			EmailField:   "email",
+			NameField:    "name",
+			GroupsField:  "groups",
+			RolesField:   "roles",
+			AdminUsers:   []string{"admin@example.com"},
+			AdminGroups:  []string{"/admin-group"},
+		},
+	}
+
+	loggingConfig := &config.LoggingConfig{
+		Level:  "info",
+		Format: "json",
+	}
+
+	logger, _ := logging.NewLogger(loggingConfig)
+	return NewOAuthAdapter(cfg, logger)
+}
+
+func TestNewOAuthAdapter(t *testing.T) {
+	cfg := &config.AuthConfig{}
+
+	loggingConfig := &config.LoggingConfig{
+		Level:  "info",
+		Format: "json",
+	}
+	logger, _ := logging.NewLogger(loggingConfig)
+
+	adapter := NewOAuthAdapter(cfg, logger)
+
+	assert.NotNil(t, adapter)
+	assert.Equal(t, cfg, adapter.config)
+	assert.Equal(t, logger, adapter.logger)
+	assert.NotNil(t, adapter.client)
+	assert.Equal(t, 10*time.Second, adapter.client.Timeout)
+}
+
+func TestGenerateState(t *testing.T) {
+	adapter := createTestOAuthAdapter()
+
+	state1, err := adapter.GenerateState()
+	require.NoError(t, err)
+	assert.NotEmpty(t, state1)
+	assert.Greater(t, len(state1), 40) // Base64 encoded 32 bytes should be longer
+
+	state2, err := adapter.GenerateState()
+	require.NoError(t, err)
+	assert.NotEmpty(t, state2)
+	assert.NotEqual(t, state1, state2) // Should generate different states
+}
+
+func TestBuildAuthURL(t *testing.T) {
+	adapter := createTestOAuthAdapter()
+	state := "test-state-123"
+
+	authURL := adapter.BuildAuthURL(state)
+
+	parsedURL, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https", parsedURL.Scheme)
+	assert.Equal(t, "provider.com", parsedURL.Host)
+	assert.Equal(t, "/auth", parsedURL.Path)
+
+	params := parsedURL.Query()
+	assert.Equal(t, "code", params.Get("response_type"))
+	assert.Equal(t, "test-client-id", params.Get("client_id"))
+	assert.Equal(t, "http://localhost:8080/auth/callback", params.Get("redirect_uri"))
+	assert.Equal(t, "openid profile email", params.Get("scope"))
+	assert.Equal(t, state, params.Get("state"))
+}
+
+func TestBuildAuthURLWithPKCE(t *testing.T) {
+	adapter := createTestOAuthAdapter()
+	state := "test-state-123"
+	codeChallenge := "test-code-challenge"
+
+	authURL := adapter.BuildAuthURL(state, codeChallenge)
+
+	parsedURL, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	params := parsedURL.Query()
+	assert.Equal(t, "code", params.Get("response_type"))
+	assert.Equal(t, "test-client-id", params.Get("client_id"))
+	assert.Equal(t, "http://localhost:8080/auth/callback", params.Get("redirect_uri"))
+	assert.Equal(t, "openid profile email", params.Get("scope"))
+	assert.Equal(t, state, params.Get("state"))
+	assert.Equal(t, codeChallenge, params.Get("code_challenge"))
+	assert.Equal(t, "S256", params.Get("code_challenge_method"))
+}
+
+func TestExchangeCodeForToken_Success(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		// Parse form data
+		err := r.ParseForm()
+		require.NoError(t, err)
+
+		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		assert.Equal(t, "test-auth-code", r.Form.Get("code"))
+		assert.Equal(t, "http://localhost:8080/auth/callback", r.Form.Get("redirect_uri"))
+		assert.Equal(t, "test-client-id", r.Form.Get("client_id"))
+		assert.Equal(t, "test-client-secret", r.Form.Get("client_secret"))
+
+		// Send successful response
+		response := map[string]interface{}{
+			"access_token":  "test-access-token",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"refresh_token": "test-refresh-token",
+			"id_token":      "test-id-token",
+			"scope":         "openid profile email",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.TokenURL = server.URL
+
+	tokenInfo, err := adapter.ExchangeCodeForToken("test-auth-code", "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-access-token", tokenInfo.AccessToken)
+	assert.Equal(t, "test-refresh-token", tokenInfo.RefreshToken)
+	assert.Equal(t, "test-id-token", tokenInfo.IDToken)
+	assert.Equal(t, 3600, tokenInfo.ExpiresIn)
+}
+
+func TestExchangeCodeForToken_WithPKCE(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+		require.NoError(t, err)
+
+		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		assert.Equal(t, "test-auth-code", r.Form.Get("code"))
+		assert.Equal(t, "test-code-verifier", r.Form.Get("code_verifier"))
+
+		response := map[string]interface{}{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.TokenURL = server.URL
+
+	tokenInfo, err := adapter.ExchangeCodeForToken("test-auth-code", "test-code-verifier")
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-access-token", tokenInfo.AccessToken)
+}
+
+func TestExchangeCodeForToken_Error(t *testing.T) {
+	// Create mock server that returns error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"}`))
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.TokenURL = server.URL
+
+	tokenInfo, err := adapter.ExchangeCodeForToken("invalid-code", "")
+
+	require.Error(t, err)
+	assert.Nil(t, tokenInfo)
+	assert.Contains(t, err.Error(), "token exchange failed")
+}
+
+func TestGetUserInfo_Success(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "Bearer test-access-token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+
+		response := map[string]interface{}{
+			"sub":            "user123",
+			"email":          "user@example.com",
+			"name":           "Test User",
+			"picture":        "https://example.com/avatar.jpg",
+			"given_name":     "Test",
+			"family_name":    "User",
+			"email_verified": true,
+			"groups":         []interface{}{"group1", "group2"},
+			"roles":          []interface{}{"user", "viewer"},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.UserInfoURL = server.URL
+
+	userInfo, err := adapter.GetUserInfo("test-access-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "user123", userInfo.Sub)
+	assert.Equal(t, "user@example.com", userInfo.Email)
+	assert.Equal(t, "Test User", userInfo.Name)
+	assert.Equal(t, "https://example.com/avatar.jpg", userInfo.Picture)
+	assert.Equal(t, "Test", userInfo.FirstName)
+	assert.Equal(t, "User", userInfo.LastName)
+	assert.True(t, userInfo.EmailVerified)
+	assert.Equal(t, []string{"group1", "group2"}, userInfo.Groups)
+	assert.Equal(t, []string{"user", "viewer"}, userInfo.Roles)
+}
+
+func TestGetUserInfo_AdminUser(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"sub":    "admin123",
+			"email":  "admin@example.com",
+			"name":   "Admin User",
+			"groups": []interface{}{"regular-group"},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.UserInfoURL = server.URL
+
+	userInfo, err := adapter.GetUserInfo("test-access-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "admin@example.com", userInfo.Email)
+	assert.Contains(t, userInfo.Groups, "admin")         // Should be added due to AdminUsers config
+	assert.Contains(t, userInfo.Groups, "regular-group") // Original group should remain
+}
+
+func TestGetUserInfo_AdminGroup(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"sub":    "user456",
+			"email":  "user@example.com",
+			"name":   "Regular User",
+			"groups": []interface{}{"/admin-group", "other-group"},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.UserInfoURL = server.URL
+
+	userInfo, err := adapter.GetUserInfo("test-access-token")
+
+	require.NoError(t, err)
+	assert.Contains(t, userInfo.Groups, "admin")        // Should be added due to AdminGroups config
+	assert.Contains(t, userInfo.Groups, "/admin-group") // Original admin group should remain
+	assert.Contains(t, userInfo.Groups, "other-group")  // Other groups should remain
+}
+
+func TestGetUserInfo_Error(t *testing.T) {
+	// Create mock server that returns error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "invalid_token"}`))
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.UserInfoURL = server.URL
+
+	userInfo, err := adapter.GetUserInfo("invalid-token")
+
+	require.Error(t, err)
+	assert.Nil(t, userInfo)
+	assert.Contains(t, err.Error(), "userinfo request failed with status 401")
+}
+
+func TestBuildProviderLogoutURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupConfig func(*config.AuthConfig)
+		idToken     string
+		expected    string
+	}{
+		{
+			name: "OAuth disabled",
+			setupConfig: func(cfg *config.AuthConfig) {
+				cfg.OAuth.Enabled = false
+			},
+			idToken:  "test-id-token",
+			expected: "/auth/login",
+		},
+		{
+			name: "Empty ID token",
+			setupConfig: func(cfg *config.AuthConfig) {
+				cfg.OAuth.Enabled = true
+			},
+			idToken:  "",
+			expected: "/auth/login",
+		},
+		{
+			name: "With configured logout URL",
+			setupConfig: func(cfg *config.AuthConfig) {
+				cfg.OAuth.Enabled = true
+				cfg.OAuth.LogoutURL = "https://provider.com/logout"
+				cfg.OAuth.RedirectURL = "http://localhost:8080/auth/callback"
+			},
+			idToken:  "test-id-token",
+			expected: "https://provider.com/logout?id_token_hint=test-id-token&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fauth%2Flogin",
+		},
+		{
+			name: "With logout URL containing query params",
+			setupConfig: func(cfg *config.AuthConfig) {
+				cfg.OAuth.Enabled = true
+				cfg.OAuth.LogoutURL = "https://provider.com/logout?param=value"
+				cfg.OAuth.RedirectURL = "http://localhost:8080/auth/callback"
+			},
+			idToken:  "test-id-token",
+			expected: "https://provider.com/logout?param=value&id_token_hint=test-id-token&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fauth%2Flogin",
+		},
+		{
+			name: "No logout URL or issuer URL",
+			setupConfig: func(cfg *config.AuthConfig) {
+				cfg.OAuth.Enabled = true
+				cfg.OAuth.LogoutURL = ""
+				cfg.OAuth.IssuerURL = ""
+			},
+			idToken:  "test-id-token",
+			expected: "/auth/login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := createTestOAuthAdapter()
+			tt.setupConfig(adapter.config)
+
+			result := adapter.BuildProviderLogoutURL(tt.idToken)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestApplyAdminOverrides(t *testing.T) {
+	tests := []struct {
+		name        string
+		userInfo    *application.UserInfo
+		adminUsers  []string
+		adminGroups []string
+		expectAdmin bool
+	}{
+		{
+			name: "Admin user by email",
+			userInfo: &application.UserInfo{
+				Email:  "admin@example.com",
+				Groups: []string{"regular-group"},
+			},
+			adminUsers:  []string{"admin@example.com"},
+			adminGroups: []string{},
+			expectAdmin: true,
+		},
+		{
+			name: "Admin user by sub",
+			userInfo: &application.UserInfo{
+				Sub:    "admin123",
+				Email:  "user@example.com",
+				Groups: []string{"regular-group"},
+			},
+			adminUsers:  []string{"admin123"},
+			adminGroups: []string{},
+			expectAdmin: true,
+		},
+		{
+			name: "Admin user by group",
+			userInfo: &application.UserInfo{
+				Email:  "user@example.com",
+				Groups: []string{"regular-group", "/admin-group"},
+			},
+			adminUsers:  []string{},
+			adminGroups: []string{"/admin-group"},
+			expectAdmin: true,
+		},
+		{
+			name: "Regular user",
+			userInfo: &application.UserInfo{
+				Email:  "user@example.com",
+				Groups: []string{"regular-group"},
+			},
+			adminUsers:  []string{"admin@example.com"},
+			adminGroups: []string{"/admin-group"},
+			expectAdmin: false,
+		},
+		{
+			name: "User already has admin group",
+			userInfo: &application.UserInfo{
+				Email:  "admin@example.com",
+				Groups: []string{"admin", "regular-group"},
+			},
+			adminUsers:  []string{"admin@example.com"},
+			adminGroups: []string{},
+			expectAdmin: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := createTestOAuthAdapter()
+			adapter.config.OAuth.AdminUsers = tt.adminUsers
+			adapter.config.OAuth.AdminGroups = tt.adminGroups
+
+			adapter.applyAdminOverrides(tt.userInfo)
+
+			hasAdmin := false
+			for _, group := range tt.userInfo.Groups {
+				if group == "admin" || group == "/admin" {
+					hasAdmin = true
+					break
+				}
+			}
+
+			assert.Equal(t, tt.expectAdmin, hasAdmin)
+		})
+	}
+}
+
+func TestGetUserInfo_CustomFieldMappings(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := map[string]interface{}{
+			"user_id":       "custom123",
+			"email_address": "custom@example.com",
+			"display_name":  "Custom User",
+			"user_groups":   []interface{}{"custom-group"},
+			"user_roles":    []interface{}{"custom-role"},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	adapter := createTestOAuthAdapter()
+	adapter.config.OAuth.UserInfoURL = server.URL
+	// Override field mappings
+	adapter.config.OAuth.UserIDField = "user_id"
+	adapter.config.OAuth.EmailField = "email_address"
+	adapter.config.OAuth.NameField = "display_name"
+	adapter.config.OAuth.GroupsField = "user_groups"
+	adapter.config.OAuth.RolesField = "user_roles"
+
+	userInfo, err := adapter.GetUserInfo("test-access-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "custom123", userInfo.Sub)
+	assert.Equal(t, "custom@example.com", userInfo.Email)
+	assert.Equal(t, "Custom User", userInfo.Name)
+	assert.Equal(t, []string{"custom-group"}, userInfo.Groups)
+	assert.Equal(t, []string{"custom-role"}, userInfo.Roles)
+}
+
+// Benchmark tests
+func BenchmarkGenerateState(b *testing.B) {
+	adapter := createTestOAuthAdapter()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := adapter.GenerateState()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildAuthURL(b *testing.B) {
+	adapter := createTestOAuthAdapter()
+	state := "test-state"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = adapter.BuildAuthURL(state)
+	}
+}

--- a/internal/domains/auth/interfaces/oauth_adapter_test.go
+++ b/internal/domains/auth/interfaces/oauth_adapter_test.go
@@ -4,527 +4,681 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"testing"
+	"strings"
 	"time"
 
 	"github.com/guidewire-oss/fern-platform/internal/domains/auth/application"
+	_ "github.com/guidewire-oss/fern-platform/internal/domains/auth/application"
 	"github.com/guidewire-oss/fern-platform/pkg/config"
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func createTestOAuthAdapter() *OAuthAdapter {
-	cfg := &config.AuthConfig{
-		OAuth: config.OAuthConfig{
-			Enabled:      true,
-			ClientID:     "test-client-id",
-			ClientSecret: "test-client-secret",
-			RedirectURL:  "http://localhost:8080/auth/callback",
-			AuthURL:      "https://provider.com/auth",
-			TokenURL:     "https://provider.com/token",
-			UserInfoURL:  "https://provider.com/userinfo",
-			LogoutURL:    "https://provider.com/logout",
-			IssuerURL:    "https://provider.com",
-			Scopes:       []string{"openid", "profile", "email"},
-			UserIDField:  "sub",
-			EmailField:   "email",
-			NameField:    "name",
-			GroupsField:  "groups",
-			RolesField:   "roles",
-			AdminUsers:   []string{"admin@example.com"},
-			AdminGroups:  []string{"/admin-group"},
-		},
-	}
+var _ = Describe("OAuthAdapter", Label("auth"), func() {
+	var (
+		authConfig *config.AuthConfig
+		logger     *logging.Logger
+		adapter    *OAuthAdapter
+	)
 
-	loggingConfig := &config.LoggingConfig{
-		Level:  "info",
-		Format: "json",
-	}
-
-	logger, _ := logging.NewLogger(loggingConfig)
-	return NewOAuthAdapter(cfg, logger)
-}
-
-func TestNewOAuthAdapter(t *testing.T) {
-	cfg := &config.AuthConfig{}
-
-	loggingConfig := &config.LoggingConfig{
-		Level:  "info",
-		Format: "json",
-	}
-	logger, _ := logging.NewLogger(loggingConfig)
-
-	adapter := NewOAuthAdapter(cfg, logger)
-
-	assert.NotNil(t, adapter)
-	assert.Equal(t, cfg, adapter.config)
-	assert.Equal(t, logger, adapter.logger)
-	assert.NotNil(t, adapter.client)
-	assert.Equal(t, 10*time.Second, adapter.client.Timeout)
-}
-
-func TestGenerateState(t *testing.T) {
-	adapter := createTestOAuthAdapter()
-
-	state1, err := adapter.GenerateState()
-	require.NoError(t, err)
-	assert.NotEmpty(t, state1)
-	assert.Greater(t, len(state1), 40) // Base64 encoded 32 bytes should be longer
-
-	state2, err := adapter.GenerateState()
-	require.NoError(t, err)
-	assert.NotEmpty(t, state2)
-	assert.NotEqual(t, state1, state2) // Should generate different states
-}
-
-func TestBuildAuthURL(t *testing.T) {
-	adapter := createTestOAuthAdapter()
-	state := "test-state-123"
-
-	authURL := adapter.BuildAuthURL(state)
-
-	parsedURL, err := url.Parse(authURL)
-	require.NoError(t, err)
-
-	assert.Equal(t, "https", parsedURL.Scheme)
-	assert.Equal(t, "provider.com", parsedURL.Host)
-	assert.Equal(t, "/auth", parsedURL.Path)
-
-	params := parsedURL.Query()
-	assert.Equal(t, "code", params.Get("response_type"))
-	assert.Equal(t, "test-client-id", params.Get("client_id"))
-	assert.Equal(t, "http://localhost:8080/auth/callback", params.Get("redirect_uri"))
-	assert.Equal(t, "openid profile email", params.Get("scope"))
-	assert.Equal(t, state, params.Get("state"))
-}
-
-func TestBuildAuthURLWithPKCE(t *testing.T) {
-	adapter := createTestOAuthAdapter()
-	state := "test-state-123"
-	codeChallenge := "test-code-challenge"
-
-	authURL := adapter.BuildAuthURL(state, codeChallenge)
-
-	parsedURL, err := url.Parse(authURL)
-	require.NoError(t, err)
-
-	params := parsedURL.Query()
-	assert.Equal(t, "code", params.Get("response_type"))
-	assert.Equal(t, "test-client-id", params.Get("client_id"))
-	assert.Equal(t, "http://localhost:8080/auth/callback", params.Get("redirect_uri"))
-	assert.Equal(t, "openid profile email", params.Get("scope"))
-	assert.Equal(t, state, params.Get("state"))
-	assert.Equal(t, codeChallenge, params.Get("code_challenge"))
-	assert.Equal(t, "S256", params.Get("code_challenge_method"))
-}
-
-func TestExchangeCodeForToken_Success(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
-		assert.Equal(t, "application/json", r.Header.Get("Accept"))
-
-		// Parse form data
-		err := r.ParseForm()
-		require.NoError(t, err)
-
-		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
-		assert.Equal(t, "test-auth-code", r.Form.Get("code"))
-		assert.Equal(t, "http://localhost:8080/auth/callback", r.Form.Get("redirect_uri"))
-		assert.Equal(t, "test-client-id", r.Form.Get("client_id"))
-		assert.Equal(t, "test-client-secret", r.Form.Get("client_secret"))
-
-		// Send successful response
-		response := map[string]interface{}{
-			"access_token":  "test-access-token",
-			"token_type":    "Bearer",
-			"expires_in":    3600,
-			"refresh_token": "test-refresh-token",
-			"id_token":      "test-id-token",
-			"scope":         "openid profile email",
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.TokenURL = server.URL
-
-	tokenInfo, err := adapter.ExchangeCodeForToken("test-auth-code", "")
-
-	require.NoError(t, err)
-	assert.Equal(t, "test-access-token", tokenInfo.AccessToken)
-	assert.Equal(t, "test-refresh-token", tokenInfo.RefreshToken)
-	assert.Equal(t, "test-id-token", tokenInfo.IDToken)
-	assert.Equal(t, 3600, tokenInfo.ExpiresIn)
-}
-
-func TestExchangeCodeForToken_WithPKCE(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := r.ParseForm()
-		require.NoError(t, err)
-
-		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
-		assert.Equal(t, "test-auth-code", r.Form.Get("code"))
-		assert.Equal(t, "test-code-verifier", r.Form.Get("code_verifier"))
-
-		response := map[string]interface{}{
-			"access_token": "test-access-token",
-			"token_type":   "Bearer",
-			"expires_in":   3600,
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.TokenURL = server.URL
-
-	tokenInfo, err := adapter.ExchangeCodeForToken("test-auth-code", "test-code-verifier")
-
-	require.NoError(t, err)
-	assert.Equal(t, "test-access-token", tokenInfo.AccessToken)
-}
-
-func TestExchangeCodeForToken_Error(t *testing.T) {
-	// Create mock server that returns error
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error": "invalid_grant", "error_description": "The provided authorization grant is invalid"}`))
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.TokenURL = server.URL
-
-	tokenInfo, err := adapter.ExchangeCodeForToken("invalid-code", "")
-
-	require.Error(t, err)
-	assert.Nil(t, tokenInfo)
-	assert.Contains(t, err.Error(), "token exchange failed")
-}
-
-func TestGetUserInfo_Success(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "Bearer test-access-token", r.Header.Get("Authorization"))
-		assert.Equal(t, "application/json", r.Header.Get("Accept"))
-
-		response := map[string]interface{}{
-			"sub":            "user123",
-			"email":          "user@example.com",
-			"name":           "Test User",
-			"picture":        "https://example.com/avatar.jpg",
-			"given_name":     "Test",
-			"family_name":    "User",
-			"email_verified": true,
-			"groups":         []interface{}{"group1", "group2"},
-			"roles":          []interface{}{"user", "viewer"},
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.UserInfoURL = server.URL
-
-	userInfo, err := adapter.GetUserInfo("test-access-token")
-
-	require.NoError(t, err)
-	assert.Equal(t, "user123", userInfo.Sub)
-	assert.Equal(t, "user@example.com", userInfo.Email)
-	assert.Equal(t, "Test User", userInfo.Name)
-	assert.Equal(t, "https://example.com/avatar.jpg", userInfo.Picture)
-	assert.Equal(t, "Test", userInfo.FirstName)
-	assert.Equal(t, "User", userInfo.LastName)
-	assert.True(t, userInfo.EmailVerified)
-	assert.Equal(t, []string{"group1", "group2"}, userInfo.Groups)
-	assert.Equal(t, []string{"user", "viewer"}, userInfo.Roles)
-}
-
-func TestGetUserInfo_AdminUser(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := map[string]interface{}{
-			"sub":    "admin123",
-			"email":  "admin@example.com",
-			"name":   "Admin User",
-			"groups": []interface{}{"regular-group"},
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.UserInfoURL = server.URL
-
-	userInfo, err := adapter.GetUserInfo("test-access-token")
-
-	require.NoError(t, err)
-	assert.Equal(t, "admin@example.com", userInfo.Email)
-	assert.Contains(t, userInfo.Groups, "admin")         // Should be added due to AdminUsers config
-	assert.Contains(t, userInfo.Groups, "regular-group") // Original group should remain
-}
-
-func TestGetUserInfo_AdminGroup(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := map[string]interface{}{
-			"sub":    "user456",
-			"email":  "user@example.com",
-			"name":   "Regular User",
-			"groups": []interface{}{"/admin-group", "other-group"},
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.UserInfoURL = server.URL
-
-	userInfo, err := adapter.GetUserInfo("test-access-token")
-
-	require.NoError(t, err)
-	assert.Contains(t, userInfo.Groups, "admin")        // Should be added due to AdminGroups config
-	assert.Contains(t, userInfo.Groups, "/admin-group") // Original admin group should remain
-	assert.Contains(t, userInfo.Groups, "other-group")  // Other groups should remain
-}
-
-func TestGetUserInfo_Error(t *testing.T) {
-	// Create mock server that returns error
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"error": "invalid_token"}`))
-	}))
-	defer server.Close()
-
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.UserInfoURL = server.URL
-
-	userInfo, err := adapter.GetUserInfo("invalid-token")
-
-	require.Error(t, err)
-	assert.Nil(t, userInfo)
-	assert.Contains(t, err.Error(), "userinfo request failed with status 401")
-}
-
-func TestBuildProviderLogoutURL(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupConfig func(*config.AuthConfig)
-		idToken     string
-		expected    string
-	}{
-		{
-			name: "OAuth disabled",
-			setupConfig: func(cfg *config.AuthConfig) {
-				cfg.OAuth.Enabled = false
+	BeforeEach(func() {
+		authConfig = &config.AuthConfig{
+			OAuth: config.OAuthConfig{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				RedirectURL:  "http://localhost/auth/callback",
+				AuthURL:      "http://authserver/authorize",
+				TokenURL:     "http://authserver/token",
+				UserInfoURL:  "http://authserver/userinfo",
+				Scopes:       []string{"openid", "profile", "email"},
+				UserIDField:  "sub",
+				EmailField:   "email",
+				NameField:    "name",
+				GroupsField:  "groups",
+				RolesField:   "roles",
+				Enabled:      true,
 			},
-			idToken:  "test-id-token",
-			expected: "/auth/login",
-		},
-		{
-			name: "Empty ID token",
-			setupConfig: func(cfg *config.AuthConfig) {
-				cfg.OAuth.Enabled = true
-			},
-			idToken:  "",
-			expected: "/auth/login",
-		},
-		{
-			name: "With configured logout URL",
-			setupConfig: func(cfg *config.AuthConfig) {
-				cfg.OAuth.Enabled = true
-				cfg.OAuth.LogoutURL = "https://provider.com/logout"
-				cfg.OAuth.RedirectURL = "http://localhost:8080/auth/callback"
-			},
-			idToken:  "test-id-token",
-			expected: "https://provider.com/logout?id_token_hint=test-id-token&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fauth%2Flogin",
-		},
-		{
-			name: "With logout URL containing query params",
-			setupConfig: func(cfg *config.AuthConfig) {
-				cfg.OAuth.Enabled = true
-				cfg.OAuth.LogoutURL = "https://provider.com/logout?param=value"
-				cfg.OAuth.RedirectURL = "http://localhost:8080/auth/callback"
-			},
-			idToken:  "test-id-token",
-			expected: "https://provider.com/logout?param=value&id_token_hint=test-id-token&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fauth%2Flogin",
-		},
-		{
-			name: "No logout URL or issuer URL",
-			setupConfig: func(cfg *config.AuthConfig) {
-				cfg.OAuth.Enabled = true
-				cfg.OAuth.LogoutURL = ""
-				cfg.OAuth.IssuerURL = ""
-			},
-			idToken:  "test-id-token",
-			expected: "/auth/login",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			adapter := createTestOAuthAdapter()
-			tt.setupConfig(adapter.config)
-
-			result := adapter.BuildProviderLogoutURL(tt.idToken)
-			assert.Equal(t, tt.expected, result)
+		}
+		logger, _ = logging.NewLogger(&config.LoggingConfig{
+			Level: "debug",
 		})
-	}
-}
+		adapter = NewOAuthAdapter(authConfig, logger)
+	})
 
-func TestApplyAdminOverrides(t *testing.T) {
-	tests := []struct {
-		name        string
-		userInfo    *application.UserInfo
-		adminUsers  []string
-		adminGroups []string
-		expectAdmin bool
-	}{
-		{
-			name: "Admin user by email",
-			userInfo: &application.UserInfo{
-				Email:  "admin@example.com",
-				Groups: []string{"regular-group"},
-			},
-			adminUsers:  []string{"admin@example.com"},
-			adminGroups: []string{},
-			expectAdmin: true,
-		},
-		{
-			name: "Admin user by sub",
-			userInfo: &application.UserInfo{
-				Sub:    "admin123",
-				Email:  "user@example.com",
-				Groups: []string{"regular-group"},
-			},
-			adminUsers:  []string{"admin123"},
-			adminGroups: []string{},
-			expectAdmin: true,
-		},
-		{
-			name: "Admin user by group",
-			userInfo: &application.UserInfo{
-				Email:  "user@example.com",
-				Groups: []string{"regular-group", "/admin-group"},
-			},
-			adminUsers:  []string{},
-			adminGroups: []string{"/admin-group"},
-			expectAdmin: true,
-		},
-		{
-			name: "Regular user",
-			userInfo: &application.UserInfo{
-				Email:  "user@example.com",
-				Groups: []string{"regular-group"},
-			},
-			adminUsers:  []string{"admin@example.com"},
-			adminGroups: []string{"/admin-group"},
-			expectAdmin: false,
-		},
-		{
-			name: "User already has admin group",
-			userInfo: &application.UserInfo{
-				Email:  "admin@example.com",
-				Groups: []string{"admin", "regular-group"},
-			},
-			adminUsers:  []string{"admin@example.com"},
-			adminGroups: []string{},
-			expectAdmin: true,
-		},
-	}
+	Describe("GenerateState", func() {
+		It("generates a random state string", func() {
+			state, err := adapter.GenerateState()
+			Expect(err).To(BeNil())
+			Expect(state).NotTo(BeEmpty())
+		})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			adapter := createTestOAuthAdapter()
-			adapter.config.OAuth.AdminUsers = tt.adminUsers
-			adapter.config.OAuth.AdminGroups = tt.adminGroups
+		It("generates different states on subsequent calls", func() {
+			state1, err1 := adapter.GenerateState()
+			state2, err2 := adapter.GenerateState()
+			Expect(err1).To(BeNil())
+			Expect(err2).To(BeNil())
+			Expect(state1).NotTo(Equal(state2))
+		})
+	})
 
-			adapter.applyAdminOverrides(tt.userInfo)
+	Describe("BuildAuthURL", func() {
+		It("builds URL without PKCE", func() {
+			url := adapter.BuildAuthURL("xyz")
+			Expect(url).To(ContainSubstring("response_type=code"))
+			Expect(url).To(ContainSubstring("state=xyz"))
+			Expect(url).To(ContainSubstring("client_id=client-id"))
+			Expect(url).To(ContainSubstring("redirect_uri=http%3A%2F%2Flocalhost%2Fauth%2Fcallback"))
+			Expect(url).To(ContainSubstring("scope=openid+profile+email"))
+			Expect(url).NotTo(ContainSubstring("code_challenge"))
+		})
 
-			hasAdmin := false
-			for _, group := range tt.userInfo.Groups {
-				if group == "admin" || group == "/admin" {
-					hasAdmin = true
-					break
+		It("builds URL with PKCE", func() {
+			url := adapter.BuildAuthURL("xyz", "challenge123")
+			Expect(url).To(ContainSubstring("code_challenge=challenge123"))
+			Expect(url).To(ContainSubstring("code_challenge_method=S256"))
+		})
+
+		It("builds URL with empty scopes", func() {
+			authConfig.OAuth.Scopes = []string{}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			url := adapter.BuildAuthURL("state123")
+			Expect(url).To(ContainSubstring("scope="))
+			Expect(url).To(ContainSubstring("state=state123"))
+		})
+
+		It("builds URL with single scope", func() {
+			authConfig.OAuth.Scopes = []string{"openid"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			url := adapter.BuildAuthURL("state456")
+			Expect(url).To(ContainSubstring("scope=openid"))
+		})
+
+		It("ignores empty code challenge", func() {
+			url := adapter.BuildAuthURL("xyz", "")
+			Expect(url).NotTo(ContainSubstring("code_challenge"))
+			Expect(url).NotTo(ContainSubstring("code_challenge_method"))
+		})
+	})
+
+	Describe("ExchangeCodeForToken", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("successfully exchanges code for token", func() {
+			tokenResp := map[string]interface{}{
+				"access_token":  "access123",
+				"refresh_token": "refresh123",
+				"id_token":      "id123",
+				"expires_in":    3600,
+			}
+			body, _ := json.Marshal(tokenResp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write(body)
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code123", "")
+			Expect(err).To(BeNil())
+			Expect(token.AccessToken).To(Equal("access123"))
+			Expect(token.RefreshToken).To(Equal("refresh123"))
+			Expect(token.IDToken).To(Equal("id123"))
+		})
+
+		It("successfully exchanges code with PKCE verifier", func() {
+			var receivedVerifier string
+			tokenResp := map[string]interface{}{
+				"access_token": "access-pkce",
+				"expires_in":   7200,
+			}
+			body, _ := json.Marshal(tokenResp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				r.ParseForm()
+				receivedVerifier = r.Form.Get("code_verifier")
+				Expect(r.Form.Get("grant_type")).To(Equal("authorization_code"))
+				Expect(r.Form.Get("code")).To(Equal("auth-code"))
+				Expect(r.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
+				Expect(r.Header.Get("Accept")).To(Equal("application/json"))
+				w.WriteHeader(http.StatusOK)
+				w.Write(body)
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("auth-code", "verifier123")
+			Expect(err).To(BeNil())
+			Expect(receivedVerifier).To(Equal("verifier123"))
+			Expect(token.AccessToken).To(Equal("access-pkce"))
+			Expect(token.ExpiresIn).To(Equal(7200))
+		})
+
+		It("handles token response without optional fields", func() {
+			tokenResp := map[string]interface{}{
+				"access_token": "minimal-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}
+			body, _ := json.Marshal(tokenResp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write(body)
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code", "")
+			Expect(err).To(BeNil())
+			Expect(token.AccessToken).To(Equal("minimal-token"))
+			Expect(token.RefreshToken).To(BeEmpty())
+			Expect(token.IDToken).To(BeEmpty())
+		})
+
+		It("returns error for non-200 response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "bad request", http.StatusBadRequest)
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("token exchange failed"))
+			Expect(token).To(BeNil())
+		})
+
+		It("returns error for 401 unauthorized", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("token exchange failed"))
+			Expect(token).To(BeNil())
+		})
+
+		It("returns error for invalid JSON", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("not-json"))
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code", "")
+			Expect(err).To(HaveOccurred())
+			Expect(token).To(BeNil())
+		})
+
+		It("handles network timeout", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(11 * time.Second) // Longer than client timeout
+			}))
+			authConfig.OAuth.TokenURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code", "")
+			Expect(err).To(HaveOccurred())
+			Expect(token).To(BeNil())
+		})
+
+		It("handles invalid URL", func() {
+			authConfig.OAuth.TokenURL = "http://[invalid-url"
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			token, err := adapter.ExchangeCodeForToken("code", "")
+			Expect(err).To(HaveOccurred())
+			Expect(token).To(BeNil())
+		})
+	})
+
+	Describe("GetUserInfo", func() {
+		var server *httptest.Server
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("returns parsed user info with all fields", func() {
+			resp := map[string]interface{}{
+				"sub":            "123",
+				"email":          "user@example.com",
+				"name":           "User One",
+				"picture":        "http://pic",
+				"given_name":     "User",
+				"family_name":    "One",
+				"email_verified": true,
+				"groups":         []interface{}{"dev", "ops"},
+				"roles":          []interface{}{"admin"},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-token"))
+				Expect(r.Header.Get("Accept")).To(Equal("application/json"))
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			authConfig.OAuth.AdminUsers = []string{"user@example.com"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("test-token")
+			Expect(err).To(BeNil())
+			Expect(info.Email).To(Equal("user@example.com"))
+			Expect(info.Sub).To(Equal("123"))
+			Expect(info.Name).To(Equal("User One"))
+			Expect(info.Picture).To(Equal("http://pic"))
+			Expect(info.FirstName).To(Equal("User"))
+			Expect(info.LastName).To(Equal("One"))
+			Expect(info.EmailVerified).To(BeTrue())
+			Expect(info.Groups).To(ContainElement("dev"))
+			Expect(info.Groups).To(ContainElement("ops"))
+			Expect(info.Groups).To(ContainElement("admin"))
+			Expect(info.Roles).To(ContainElement("admin"))
+		})
+
+		It("handles missing optional fields", func() {
+			resp := map[string]interface{}{
+				"sub":   "456",
+				"email": "minimal@example.com",
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			Expect(info.Sub).To(Equal("456"))
+			Expect(info.Email).To(Equal("minimal@example.com"))
+			Expect(info.Name).To(BeEmpty())
+			Expect(info.Picture).To(BeEmpty())
+			Expect(info.Groups).To(BeEmpty())
+			Expect(info.Roles).To(BeEmpty())
+		})
+
+		It("handles fields with wrong types", func() {
+			resp := map[string]interface{}{
+				"sub":            123,  // wrong type (number instead of string)
+				"email":          true, // wrong type (bool instead of string)
+				"name":           "Valid Name",
+				"email_verified": "yes",          // wrong type (string instead of bool)
+				"groups":         "not-an-array", // wrong type (string instead of array)
+				"roles":          123,            // wrong type (number instead of array)
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			Expect(info.Sub).To(BeEmpty())   // Wrong type, should be empty
+			Expect(info.Email).To(BeEmpty()) // Wrong type, should be empty
+			Expect(info.Name).To(Equal("Valid Name"))
+			Expect(info.EmailVerified).To(BeFalse()) // Wrong type, defaults to false
+			Expect(info.Groups).To(BeEmpty())        // Wrong type, should be empty
+			Expect(info.Roles).To(BeEmpty())         // Wrong type, should be empty
+		})
+
+		It("handles groups array with mixed types", func() {
+			resp := map[string]interface{}{
+				"sub":    "789",
+				"groups": []interface{}{"valid-group", 123, true, "another-group"},
+				"roles":  []interface{}{456, "valid-role", false},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			Expect(info.Groups).To(HaveLen(2))
+			Expect(info.Groups).To(ContainElement("valid-group"))
+			Expect(info.Groups).To(ContainElement("another-group"))
+			Expect(info.Roles).To(HaveLen(1))
+			Expect(info.Roles).To(ContainElement("valid-role"))
+		})
+
+		It("applies admin override based on sub field", func() {
+			resp := map[string]interface{}{
+				"sub":    "admin-sub-123",
+				"email":  "other@example.com",
+				"groups": []interface{}{"users"},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			authConfig.OAuth.AdminUsers = []string{"admin-sub-123"} // Match by sub
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			Expect(info.Groups).To(ContainElement("admin"))
+		})
+
+		It("does not duplicate admin group if already present", func() {
+			resp := map[string]interface{}{
+				"sub":    "sub123",
+				"email":  "admin@example.com",
+				"groups": []interface{}{"users", "admin"},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			authConfig.OAuth.AdminUsers = []string{"admin@example.com"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			adminCount := 0
+			for _, g := range info.Groups {
+				if g == "admin" {
+					adminCount++
 				}
 			}
-
-			assert.Equal(t, tt.expectAdmin, hasAdmin)
+			Expect(adminCount).To(Equal(1))
 		})
-	}
-}
 
-func TestGetUserInfo_CustomFieldMappings(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := map[string]interface{}{
-			"user_id":       "custom123",
-			"email_address": "custom@example.com",
-			"display_name":  "Custom User",
-			"user_groups":   []interface{}{"custom-group"},
-			"user_roles":    []interface{}{"custom-role"},
-		}
+		It("recognizes /admin group as admin", func() {
+			resp := map[string]interface{}{
+				"sub":    "sub456",
+				"email":  "user@example.com",
+				"groups": []interface{}{"/admin", "users"},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			authConfig.OAuth.AdminUsers = []string{"user@example.com"}
+			adapter = NewOAuthAdapter(authConfig, logger)
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			// Should not add another admin group since /admin is already present
+			adminCount := 0
+			for _, g := range info.Groups {
+				if g == "admin" || g == "/admin" {
+					adminCount++
+				}
+			}
+			Expect(adminCount).To(Equal(1))
+		})
 
-	adapter := createTestOAuthAdapter()
-	adapter.config.OAuth.UserInfoURL = server.URL
-	// Override field mappings
-	adapter.config.OAuth.UserIDField = "user_id"
-	adapter.config.OAuth.EmailField = "email_address"
-	adapter.config.OAuth.NameField = "display_name"
-	adapter.config.OAuth.GroupsField = "user_groups"
-	adapter.config.OAuth.RolesField = "user_roles"
+		It("applies admin override based on AdminGroups", func() {
+			resp := map[string]interface{}{
+				"sub":    "sub123",
+				"email":  "x@example.com",
+				"groups": []interface{}{"managers"},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			authConfig.OAuth.AdminGroups = []string{"managers"}
+			adapter = NewOAuthAdapter(authConfig, logger)
 
-	userInfo, err := adapter.GetUserInfo("test-access-token")
+			info, err := adapter.GetUserInfo("access")
+			Expect(err).To(BeNil())
+			Expect(info.Groups).To(ContainElement("admin"))
+		})
 
-	require.NoError(t, err)
-	assert.Equal(t, "custom123", userInfo.Sub)
-	assert.Equal(t, "custom@example.com", userInfo.Email)
-	assert.Equal(t, "Custom User", userInfo.Name)
-	assert.Equal(t, []string{"custom-group"}, userInfo.Groups)
-	assert.Equal(t, []string{"custom-role"}, userInfo.Roles)
-}
+		It("applies admin override for multiple admin groups", func() {
+			resp := map[string]interface{}{
+				"sub":    "sub789",
+				"email":  "user@example.com",
+				"groups": []interface{}{"developers", "team-leads"},
+			}
+			body, _ := json.Marshal(resp)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write(body)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			authConfig.OAuth.AdminGroups = []string{"managers", "team-leads", "executives"}
+			adapter = NewOAuthAdapter(authConfig, logger)
 
-// Benchmark tests
-func BenchmarkGenerateState(b *testing.B) {
-	adapter := createTestOAuthAdapter()
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(BeNil())
+			Expect(info.Groups).To(ContainElement("admin"))
+		})
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := adapter.GenerateState()
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
+		It("returns error on non-200 response", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "fail", http.StatusUnauthorized)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
 
-func BenchmarkBuildAuthURL(b *testing.B) {
-	adapter := createTestOAuthAdapter()
-	state := "test-state"
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("userinfo request failed with status 401"))
+			Expect(info).To(BeNil())
+		})
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = adapter.BuildAuthURL(state)
-	}
-}
+		It("returns error for 403 forbidden", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("userinfo request failed with status 403"))
+			Expect(info).To(BeNil())
+		})
+
+		It("returns error on invalid JSON", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("bad-json"))
+			}))
+			authConfig.OAuth.UserInfoURL = server.URL
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(HaveOccurred())
+			Expect(info).To(BeNil())
+		})
+
+		It("handles network error", func() {
+			authConfig.OAuth.UserInfoURL = "http://non-existent-server-12345.invalid"
+			adapter = NewOAuthAdapter(authConfig, logger)
+
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(HaveOccurred())
+			Expect(info).To(BeNil())
+		})
+	})
+
+	Describe("BuildProviderLogoutURL", func() {
+		It("returns local login if disabled", func() {
+			authConfig.OAuth.Enabled = false
+			adapter = NewOAuthAdapter(authConfig, logger)
+			Expect(adapter.BuildProviderLogoutURL("id")).To(Equal("/auth/login"))
+		})
+
+		It("returns local login if no ID token", func() {
+			Expect(adapter.BuildProviderLogoutURL("")).To(Equal("/auth/login"))
+		})
+
+		It("uses configured LogoutURL", func() {
+			authConfig.OAuth.LogoutURL = "http://auth/logout"
+			url := adapter.BuildProviderLogoutURL("id123")
+			Expect(url).To(ContainSubstring("id_token_hint=id123"))
+			Expect(url).To(ContainSubstring("post_logout_redirect_uri="))
+			Expect(url).To(ContainSubstring("%2Fauth%2Flogin"))
+		})
+
+		It("handles LogoutURL with existing query params", func() {
+			authConfig.OAuth.LogoutURL = "http://auth/logout?param=value"
+			url := adapter.BuildProviderLogoutURL("id456")
+			Expect(url).To(ContainSubstring("param=value"))
+			Expect(url).To(ContainSubstring("&id_token_hint=id456"))
+			Expect(url).NotTo(ContainSubstring("?id_token_hint"))
+		})
+
+		It("properly URL-encodes the ID token", func() {
+			authConfig.OAuth.LogoutURL = "http://auth/logout"
+			url := adapter.BuildProviderLogoutURL("id/with+special=chars")
+			Expect(url).To(ContainSubstring("id_token_hint=id%2Fwith%2Bspecial%3Dchars"))
+		})
+
+		It("uses IssuerURL fallback", func() {
+			authConfig.OAuth.LogoutURL = ""
+			authConfig.OAuth.IssuerURL = "http://issuer"
+			url := adapter.BuildProviderLogoutURL("id123")
+			Expect(url).To(ContainSubstring("protocol/openid-connect/logout"))
+			Expect(url).To(ContainSubstring("id_token_hint=id123"))
+		})
+
+		It("handles IssuerURL with trailing slash", func() {
+			authConfig.OAuth.LogoutURL = ""
+			authConfig.OAuth.IssuerURL = "http://issuer/"
+			url := adapter.BuildProviderLogoutURL("id789")
+			Expect(url).To(Equal("http://issuer/protocol/openid-connect/logout?id_token_hint=id789&post_logout_redirect_uri=http%3A%2F%2Flocalhost%2Fauth%2Flogin"))
+			Expect(url).NotTo(ContainSubstring("//protocol"))
+		})
+
+		It("handles empty RedirectURL", func() {
+			authConfig.OAuth.LogoutURL = "http://auth/logout"
+			authConfig.OAuth.RedirectURL = ""
+			url := adapter.BuildProviderLogoutURL("id123")
+			Expect(url).To(ContainSubstring("id_token_hint=id123"))
+			Expect(url).NotTo(ContainSubstring("post_logout_redirect_uri"))
+		})
+
+		It("falls back to /auth/login when no logout URL configured", func() {
+			authConfig.OAuth.LogoutURL = ""
+			authConfig.OAuth.IssuerURL = ""
+			Expect(adapter.BuildProviderLogoutURL("id123")).To(Equal("/auth/login"))
+		})
+	})
+
+	Describe("applyAdminOverrides", func() {
+		var userInfo *application.UserInfo
+
+		BeforeEach(func() {
+			userInfo = &application.UserInfo{
+				Sub:    "user123",
+				Email:  "test@example.com",
+				Groups: []string{"users"},
+			}
+		})
+
+		It("adds admin group for AdminUsers email match", func() {
+			authConfig.OAuth.AdminUsers = []string{"test@example.com"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(ContainElement("admin"))
+		})
+
+		It("adds admin group for AdminUsers sub match", func() {
+			authConfig.OAuth.AdminUsers = []string{"user123"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(ContainElement("admin"))
+		})
+
+		It("does not add admin if not in AdminUsers", func() {
+			authConfig.OAuth.AdminUsers = []string{"other@example.com"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			originalGroups := len(userInfo.Groups)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(HaveLen(originalGroups))
+			Expect(userInfo.Groups).NotTo(ContainElement("admin"))
+		})
+
+		It("adds admin group for AdminGroups match", func() {
+			userInfo.Groups = append(userInfo.Groups, "managers")
+			authConfig.OAuth.AdminGroups = []string{"managers"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(ContainElement("admin"))
+		})
+
+		It("prioritizes AdminUsers over AdminGroups", func() {
+			userInfo.Groups = append(userInfo.Groups, "blocked-group")
+			authConfig.OAuth.AdminUsers = []string{"test@example.com"}
+			authConfig.OAuth.AdminGroups = []string{"blocked-group"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(ContainElement("admin"))
+		})
+
+		It("handles empty admin configurations", func() {
+			authConfig.OAuth.AdminUsers = []string{}
+			authConfig.OAuth.AdminGroups = []string{}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			originalGroups := len(userInfo.Groups)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(HaveLen(originalGroups))
+			Expect(userInfo.Groups).NotTo(ContainElement("admin"))
+		})
+
+		It("handles nil groups", func() {
+			userInfo.Groups = nil
+			authConfig.OAuth.AdminUsers = []string{"test@example.com"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			adapter.applyAdminOverrides(userInfo)
+			Expect(userInfo.Groups).To(HaveLen(1))
+			Expect(userInfo.Groups).To(ContainElement("admin"))
+		})
+	})
+
+	Describe("NewOAuthAdapter", func() {
+		It("creates adapter with correct configuration", func() {
+			newAdapter := NewOAuthAdapter(authConfig, logger)
+			Expect(newAdapter).NotTo(BeNil())
+			Expect(newAdapter.config).To(Equal(authConfig))
+			Expect(newAdapter.logger).To(Equal(logger))
+			Expect(newAdapter.client).NotTo(BeNil())
+			Expect(newAdapter.client.Timeout).To(Equal(10 * time.Second))
+		})
+	})
+
+	Describe("Edge Cases", func() {
+		It("handles special characters in scopes", func() {
+			authConfig.OAuth.Scopes = []string{"openid", "profile email", "custom:scope"}
+			adapter = NewOAuthAdapter(authConfig, logger)
+			url := adapter.BuildAuthURL("state")
+			Expect(url).To(ContainSubstring("scope=openid+profile+email+custom%3Ascope"))
+		})
+
+		It("handles malformed UserInfoURL", func() {
+			authConfig.OAuth.UserInfoURL = "://invalid-url"
+			adapter = NewOAuthAdapter(authConfig, logger)
+			info, err := adapter.GetUserInfo("token")
+			Expect(err).To(HaveOccurred())
+			Expect(info).To(BeNil())
+		})
+
+		It("handles very long state parameter", func() {
+			longState := strings.Repeat("a", 1000)
+			url := adapter.BuildAuthURL(longState)
+			Expect(url).To(ContainSubstring("state=" + longState))
+		})
+	})
+})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -440,7 +440,7 @@ func (m *Manager) bindEnvVars() error {
 	if err := viper.BindEnv("logging.format", "LOG_FORMAT"); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 
@@ -462,9 +462,6 @@ func (m *Manager) validate(config *Config) error {
 			// OAuth validation
 			if config.Auth.OAuth.ClientID == "" {
 				return fmt.Errorf("oauth is enabled but client ID is missing")
-			}
-			if config.Auth.OAuth.ClientSecret == "" {
-				return fmt.Errorf("oauth is enabled but client secret is missing")
 			}
 			if config.Auth.OAuth.AuthURL == "" {
 				return fmt.Errorf("oauth is enabled but auth URL is missing")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -483,6 +483,10 @@ func (m *Manager) validate(config *Config) error {
 	return nil
 }
 
+func (m *Manager) GetString(key string) string {
+	return viper.GetString(key)
+}
+
 // GetConfig returns the global configuration instance
 func GetConfig() *Config {
 	if globalConfig == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,899 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/guidewire-oss/fern-platform/pkg/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/viper"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}
+
+var _ = Describe("Config", Label("auth"), func() {
+	var (
+		manager    *config.Manager
+		tempDir    string
+		configFile string
+	)
+
+	BeforeEach(func() {
+		// Create a temporary directory for test config files
+		var err error
+		tempDir, err = os.MkdirTemp("", "config_test")
+		Expect(err).NotTo(HaveOccurred())
+		configFile = filepath.Join(tempDir, "config.yaml")
+
+		// Reset viper state
+		viper.Reset()
+
+		// Clear any environment variables that might interfere
+		clearTestEnvVars()
+
+		// Create new manager
+		manager = config.NewManager()
+	})
+
+	AfterEach(func() {
+		// Clean up temp directory
+		os.RemoveAll(tempDir)
+
+		// Clear test environment variables
+		clearTestEnvVars()
+
+		// Reset viper state
+		viper.Reset()
+	})
+
+	Describe("NewManager", func() {
+		It("should create a new manager instance", func() {
+			manager := config.NewManager()
+			Expect(manager).NotTo(BeNil())
+		})
+	})
+
+	Describe("Load Configuration", func() {
+		Context("with default values only", func() {
+			It("should load successfully with defaults", func() {
+				err := manager.Load("")
+				Expect(err).NotTo(HaveOccurred())
+
+				cfg := config.GetConfig()
+				Expect(cfg.Server.Port).To(Equal(8080))
+				Expect(cfg.Server.Host).To(Equal("0.0.0.0"))
+				Expect(cfg.Database.Host).To(Equal("localhost"))
+				Expect(cfg.Database.Port).To(Equal(5432))
+				Expect(cfg.Database.User).To(Equal("postgres"))
+				Expect(cfg.Database.DBName).To(Equal("fern_platform"))
+			})
+		})
+
+		Context("with valid config file", func() {
+			BeforeEach(func() {
+				configContent := `
+server:
+  port: 9090
+  host: "127.0.0.1"
+  readTimeout: "45s"
+database:
+  host: "db-server"
+  port: 5433
+  user: "testuser"
+  password: "testpass"
+  dbname: "testdb"
+auth:
+  enabled: true
+  jwtSecret: "test-secret"
+  tokenExpiry: "2h"
+  oauth:
+    enabled: true
+    clientId: "test-client"
+    clientSecret: "test-secret"
+    redirectUrl: "http://localhost:8080/callback"
+    authUrl: "http://auth.example.com/auth"
+    tokenUrl: "http://auth.example.com/token"
+    userInfoUrl: "http://auth.example.com/userinfo"
+    scopes: ["openid", "profile", "email"]
+    adminUsers: ["admin@example.com"]
+    adminGroups: ["admins"]
+redis:
+  host: "redis-server"
+  port: 6380
+  password: "redis-pass"
+llm:
+  defaultProvider: "openai"
+  cacheEnabled: false
+  maxTokens: 2000
+  temperature: 0.5
+  providers:
+    openai:
+      type: "openai"
+      apiKey: "test-key"
+      model: "gpt-4"
+      enabled: true
+logging:
+  level: "debug"
+  format: "text"
+  structured: false
+monitoring:
+  metrics:
+    enabled: false
+    port: 9091
+  tracing:
+    enabled: true
+    serviceName: "test-service"
+  health:
+    path: "/healthz"
+    interval: "60s"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should load configuration from file", func() {
+				err := manager.Load(configFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				cfg := config.GetConfig()
+				Expect(cfg.Server.Port).To(Equal(9090))
+				Expect(cfg.Server.Host).To(Equal("127.0.0.1"))
+				Expect(cfg.Server.ReadTimeout).To(Equal(45 * time.Second))
+				Expect(cfg.Database.Host).To(Equal("db-server"))
+				Expect(cfg.Database.Port).To(Equal(5433))
+				Expect(cfg.Database.User).To(Equal("testuser"))
+				Expect(cfg.Database.Password).To(Equal("testpass"))
+				Expect(cfg.Database.DBName).To(Equal("testdb"))
+				Expect(cfg.Auth.Enabled).To(BeTrue())
+				Expect(cfg.Auth.JWTSecret).To(Equal("test-secret"))
+				Expect(cfg.Auth.OAuth.Enabled).To(BeTrue())
+				Expect(cfg.Auth.OAuth.ClientID).To(Equal("test-client"))
+				Expect(cfg.Auth.OAuth.AdminUsers).To(ContainElement("admin@example.com"))
+				Expect(cfg.Redis.Host).To(Equal("redis-server"))
+				Expect(cfg.LLM.DefaultProvider).To(Equal("openai"))
+				Expect(cfg.LLM.Temperature).To(Equal(float32(0.5)))
+				Expect(cfg.Monitoring.Metrics.Enabled).To(BeFalse())
+			})
+		})
+
+		Context("with environment variables", func() {
+			BeforeEach(func() {
+				// Set environment variables
+				os.Setenv("PORT", "3000")
+				os.Setenv("SERVER_HOST", "0.0.0.0")
+				os.Setenv("DB_HOST", "env-db")
+				os.Setenv("DB_PORT", "5434")
+				os.Setenv("DB_USER", "envuser")
+				os.Setenv("DB_PASSWORD", "envpass")
+				os.Setenv("DB_NAME", "envdb")
+				os.Setenv("AUTH_ENABLED", "true")
+				os.Setenv("JWT_SECRET", "env-jwt-secret")
+				os.Setenv("OAUTH_ENABLED", "true")
+				os.Setenv("OAUTH_CLIENT_ID", "env-client-id")
+				os.Setenv("OAUTH_CLIENT_SECRET", "env-client-secret")
+				os.Setenv("OAUTH_AUTH_URL", "http://env.example.com/auth")
+				os.Setenv("OAUTH_TOKEN_URL", "http://env.example.com/token")
+				os.Setenv("OAUTH_REDIRECT_URL", "http://localhost:3000/callback")
+				os.Setenv("REDIS_HOST", "env-redis")
+				os.Setenv("REDIS_PORT", "6381")
+				os.Setenv("ANTHROPIC_API_KEY", "env-anthropic-key")
+				os.Setenv("LOG_LEVEL", "warn")
+			})
+
+			It("should prioritize environment variables over defaults", func() {
+				err := manager.Load("")
+				Expect(err).NotTo(HaveOccurred())
+
+				cfg := config.GetConfig()
+				Expect(cfg.Server.Port).To(Equal(3000))
+				Expect(cfg.Database.Host).To(Equal("env-db"))
+				Expect(cfg.Database.Port).To(Equal(5434))
+				Expect(cfg.Database.User).To(Equal("envuser"))
+				Expect(cfg.Database.Password).To(Equal("envpass"))
+				Expect(cfg.Database.DBName).To(Equal("envdb"))
+				Expect(cfg.Auth.Enabled).To(BeTrue())
+				Expect(cfg.Auth.JWTSecret).To(Equal("env-jwt-secret"))
+				Expect(cfg.Auth.OAuth.Enabled).To(BeTrue())
+				Expect(cfg.Auth.OAuth.ClientID).To(Equal("env-client-id"))
+				Expect(cfg.Redis.Host).To(Equal("env-redis"))
+				Expect(cfg.Redis.Port).To(Equal(6381))
+			})
+
+			It("should handle OAuth field mappings from environment", func() {
+				os.Setenv("OAUTH_USER_ID_FIELD", "user_id")
+				os.Setenv("OAUTH_EMAIL_FIELD", "user_email")
+				os.Setenv("OAUTH_GROUPS_FIELD", "user_groups")
+				os.Setenv("OAUTH_ADMIN_GROUP_NAME", "administrators")
+
+				err := manager.Load("")
+				Expect(err).NotTo(HaveOccurred())
+
+				cfg := config.GetConfig()
+				Expect(cfg.Auth.OAuth.UserIDField).To(Equal("user_id"))
+				Expect(cfg.Auth.OAuth.EmailField).To(Equal("user_email"))
+				Expect(cfg.Auth.OAuth.GroupsField).To(Equal("user_groups"))
+				Expect(cfg.Auth.OAuth.AdminGroupName).To(Equal("administrators"))
+			})
+		})
+
+		Context("with invalid config file", func() {
+			BeforeEach(func() {
+				invalidConfig := `invalid: yaml: content: [`
+				err := os.WriteFile(configFile, []byte(invalidConfig), 0644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return an error for invalid YAML", func() {
+				err := manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to read config file"))
+			})
+		})
+
+		Context("with missing required fields", func() {
+			BeforeEach(func() {
+				configContent := `
+database:
+  host: ""  # Empty host should cause validation error
+  user: "testuser"
+  dbname: "testdb"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fail validation for missing database host", func() {
+				err := manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("database host is required"))
+			})
+		})
+	})
+
+	Describe("Configuration Validation", func() {
+		Context("database validation", func() {
+			It("should require database host", func() {
+				configContent := `
+database:
+  host: ""
+  user: "testuser"
+  dbname: "testdb"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("database host is required"))
+			})
+
+			It("should require database user", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: ""
+  dbname: "testdb"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("database user is required"))
+			})
+
+			It("should require database name", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: ""
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("database name is required"))
+			})
+		})
+
+		Context("authentication validation", func() {
+			It("should require OAuth client ID when OAuth is enabled", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: true
+    clientId: ""
+    authUrl: "http://example.com/auth"
+    tokenUrl: "http://example.com/token"
+    redirectUrl: "http://localhost/callback"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("oauth is enabled but client ID is missing"))
+			})
+
+			It("should require OAuth auth URL when OAuth is enabled", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: true
+    clientId: "test-client"
+    authUrl: ""
+    tokenUrl: "http://example.com/token"
+    redirectUrl: "http://localhost/callback"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("oauth is enabled but auth URL is missing"))
+			})
+
+			It("should require OAuth token URL when OAuth is enabled", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: true
+    clientId: "test-client"
+    authUrl: "http://example.com/auth"
+    tokenUrl: ""
+    redirectUrl: "http://localhost/callback"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("oauth is enabled but token URL is missing"))
+			})
+
+			It("should require OAuth redirect URL when OAuth is enabled", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: true
+    clientId: "test-client"
+    authUrl: "http://example.com/auth"
+    tokenUrl: "http://example.com/token"
+    redirectUrl: ""
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("oauth is enabled but redirect URL is missing"))
+			})
+
+			It("should require JWT secret or JWKS URL when auth is enabled but OAuth is disabled", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: false
+  jwtSecret: ""
+  jwksUrl: ""
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("auth is enabled but no JWT secret or JWKS URL provided"))
+			})
+
+			It("should pass validation with JWT secret", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: false
+  jwtSecret: "test-secret"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should pass validation with JWKS URL", func() {
+				configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: false
+  jwksUrl: "https://example.com/.well-known/jwks.json"
+`
+				err := os.WriteFile(configFile, []byte(configContent), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = manager.Load(configFile)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Global Getter Functions", func() {
+		BeforeEach(func() {
+			err := manager.Load("")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return config through GetConfig", func() {
+			cfg := config.GetConfig()
+			Expect(cfg).NotTo(BeNil())
+			Expect(cfg.Server.Port).To(Equal(8080))
+		})
+
+		It("should return database config through GetDatabaseConfig", func() {
+			dbCfg := config.GetDatabaseConfig()
+			Expect(dbCfg).NotTo(BeNil())
+			Expect(dbCfg.Host).To(Equal("localhost"))
+			Expect(dbCfg.Port).To(Equal(5432))
+		})
+
+		It("should return server config through GetServerConfig", func() {
+			serverCfg := config.GetServerConfig()
+			Expect(serverCfg).NotTo(BeNil())
+			Expect(serverCfg.Port).To(Equal(8080))
+			Expect(serverCfg.Host).To(Equal("0.0.0.0"))
+		})
+
+		It("should return auth config through GetAuthConfig", func() {
+			authCfg := config.GetAuthConfig()
+			Expect(authCfg).NotTo(BeNil())
+			Expect(authCfg.Enabled).To(BeFalse()) // Default value
+		})
+
+		It("should return services config through GetServicesConfig", func() {
+			servicesCfg := config.GetServicesConfig()
+			Expect(servicesCfg).NotTo(BeNil())
+		})
+
+		It("should return LLM config through GetLLMConfig", func() {
+			llmCfg := config.GetLLMConfig()
+			Expect(llmCfg).NotTo(BeNil())
+			Expect(llmCfg.DefaultProvider).To(Equal("anthropic"))
+			Expect(llmCfg.Temperature).To(Equal(float32(0.7)))
+		})
+	})
+
+	Describe("Connection String Builders", func() {
+		var dbConfig *config.DatabaseConfig
+		var redisConfig *config.RedisConfig
+
+		BeforeEach(func() {
+			err := manager.Load("")
+			Expect(err).NotTo(HaveOccurred())
+			dbConfig = config.GetDatabaseConfig()
+			redisConfig = &config.GetConfig().Redis
+		})
+
+		Context("Database Connection String", func() {
+			It("should build connection string correctly", func() {
+				dbConfig.User = "testuser"
+				dbConfig.Password = "testpass"
+				dbConfig.Host = "testhost"
+				dbConfig.Port = 5433
+				dbConfig.DBName = "testdb"
+				dbConfig.SSLMode = "require"
+
+				connStr := dbConfig.ConnectionString()
+				expected := "postgres://testuser:testpass@testhost.fern-platform:5433/testdb?sslmode=require"
+				Expect(connStr).To(Equal(expected))
+			})
+
+			It("should build migration URL correctly", func() {
+				dbConfig.User = "migrationuser"
+				dbConfig.Password = "migrationpass"
+				dbConfig.Host = "migrationhost"
+				dbConfig.Port = 5434
+				dbConfig.DBName = "migrationdb"
+				dbConfig.SSLMode = "disable"
+
+				migrationURL := dbConfig.MigrationURL()
+				expected := "postgres://migrationuser:migrationpass@migrationhost.fern-platform:5434/migrationdb?sslmode=disable"
+				Expect(migrationURL).To(Equal(expected))
+			})
+		})
+
+		Context("Redis Connection String", func() {
+			It("should build connection string without password", func() {
+				redisConfig.Host = "redis-host"
+				redisConfig.Port = 6379
+				redisConfig.DB = 0
+				redisConfig.Password = ""
+
+				connStr := redisConfig.ConnectionString()
+				expected := "redis://redis-host:6379/0"
+				Expect(connStr).To(Equal(expected))
+			})
+
+			It("should build connection string with password", func() {
+				redisConfig.Host = "redis-host"
+				redisConfig.Port = 6380
+				redisConfig.DB = 1
+				redisConfig.Password = "redis-password"
+
+				connStr := redisConfig.ConnectionString()
+				expected := "redis://:redis-password@redis-host:6380/1"
+				Expect(connStr).To(Equal(expected))
+			})
+		})
+	})
+
+	Describe("Default Values", func() {
+		It("should set correct default values", func() {
+			err := manager.Load("")
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg := config.GetConfig()
+
+			// Server defaults
+			Expect(cfg.Server.Port).To(Equal(8080))
+			Expect(cfg.Server.Host).To(Equal("0.0.0.0"))
+			Expect(cfg.Server.ReadTimeout).To(Equal(30 * time.Second))
+			Expect(cfg.Server.WriteTimeout).To(Equal(30 * time.Second))
+			Expect(cfg.Server.IdleTimeout).To(Equal(120 * time.Second))
+			Expect(cfg.Server.ShutdownTimeout).To(Equal(15 * time.Second))
+
+			// Database defaults
+			Expect(cfg.Database.Host).To(Equal("localhost"))
+			Expect(cfg.Database.Port).To(Equal(5432))
+			Expect(cfg.Database.User).To(Equal("postgres"))
+			Expect(cfg.Database.DBName).To(Equal("fern_platform"))
+			Expect(cfg.Database.SSLMode).To(Equal("disable"))
+			Expect(cfg.Database.TimeZone).To(Equal("UTC"))
+			Expect(cfg.Database.MaxOpenConns).To(Equal(25))
+			Expect(cfg.Database.MaxIdleConns).To(Equal(5))
+
+			// Auth defaults
+			Expect(cfg.Auth.Enabled).To(BeFalse())
+			Expect(cfg.Auth.TokenExpiry).To(Equal(24 * time.Hour))
+			Expect(cfg.Auth.RefreshExpiry).To(Equal(168 * time.Hour))
+
+			// OAuth defaults
+			Expect(cfg.Auth.OAuth.Enabled).To(BeFalse())
+			Expect(cfg.Auth.OAuth.Scopes).To(Equal([]string{"openid", "profile", "email"}))
+			Expect(cfg.Auth.OAuth.UserIDField).To(Equal("sub"))
+			Expect(cfg.Auth.OAuth.EmailField).To(Equal("email"))
+			Expect(cfg.Auth.OAuth.NameField).To(Equal("name"))
+			Expect(cfg.Auth.OAuth.GroupsField).To(Equal("groups"))
+			Expect(cfg.Auth.OAuth.AdminGroupName).To(Equal("admin"))
+			Expect(cfg.Auth.OAuth.ManagerGroupName).To(Equal("manager"))
+			Expect(cfg.Auth.OAuth.UserGroupName).To(Equal("user"))
+
+			// Logging defaults
+			Expect(cfg.Logging.Level).To(Equal("info"))
+			Expect(cfg.Logging.Format).To(Equal("json"))
+			Expect(cfg.Logging.Output).To(Equal("stdout"))
+			Expect(cfg.Logging.Structured).To(BeTrue())
+
+			// Redis defaults
+			Expect(cfg.Redis.Host).To(Equal("localhost"))
+			Expect(cfg.Redis.Port).To(Equal(6379))
+			Expect(cfg.Redis.DB).To(Equal(0))
+			Expect(cfg.Redis.PoolSize).To(Equal(10))
+
+			// LLM defaults
+			Expect(cfg.LLM.DefaultProvider).To(Equal("anthropic"))
+			Expect(cfg.LLM.CacheEnabled).To(BeTrue())
+			Expect(cfg.LLM.CacheTTL).To(Equal(1 * time.Hour))
+			Expect(cfg.LLM.MaxTokens).To(Equal(4000))
+			Expect(cfg.LLM.Temperature).To(Equal(float32(0.7)))
+
+			// Monitoring defaults
+			Expect(cfg.Monitoring.Metrics.Enabled).To(BeTrue())
+			Expect(cfg.Monitoring.Metrics.Path).To(Equal("/metrics"))
+			Expect(cfg.Monitoring.Metrics.Port).To(Equal(9090))
+			Expect(cfg.Monitoring.Health.Path).To(Equal("/health"))
+			Expect(cfg.Monitoring.Health.Interval).To(Equal(30 * time.Second))
+			Expect(cfg.Monitoring.Health.Timeout).To(Equal(5 * time.Second))
+		})
+	})
+
+	Describe("Error Handling", func() {
+		It("should handle config file read errors when specific file doesn't exist", func() {
+			// When a specific config file is provided but doesn't exist, it should error
+			err := manager.Load("/nonexistent/config.yaml")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read config file"))
+		})
+
+		It("should handle config directory search gracefully when no config file found", func() {
+			// Test searching in multiple config directories - should not error when no file found
+			err := manager.Load("")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Environment Variable Patterns", func() {
+		It("should handle alternative environment variable names", func() {
+			// Test alternative env var names
+			os.Setenv("POSTGRES_HOST", "alt-host")
+			os.Setenv("POSTGRES_PORT", "5435")
+			os.Setenv("POSTGRES_USER", "alt-user")
+			os.Setenv("POSTGRES_PASSWORD", "alt-pass")
+			os.Setenv("POSTGRES_DB", "alt-db")
+
+			err := manager.Load("")
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg := config.GetConfig()
+			Expect(cfg.Database.Host).To(Equal("alt-host"))
+			Expect(cfg.Database.Port).To(Equal(5435))
+			Expect(cfg.Database.User).To(Equal("alt-user"))
+			Expect(cfg.Database.Password).To(Equal("alt-pass"))
+			Expect(cfg.Database.DBName).To(Equal("alt-db"))
+		})
+
+		It("should handle LLM provider API keys from environment", func() {
+			os.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+			os.Setenv("OPENAI_API_KEY", "test-openai-key")
+			os.Setenv("HUGGINGFACE_API_KEY", "test-hf-key")
+
+			err := manager.Load("")
+			Expect(err).NotTo(HaveOccurred())
+
+			// These would be set in the viper instance
+			// We can verify they were bound by checking viper directly
+			Expect(viper.GetString("llm.providers.anthropic.apiKey")).To(Equal("test-anthropic-key"))
+			Expect(viper.GetString("llm.providers.openai.apiKey")).To(Equal("test-openai-key"))
+			Expect(viper.GetString("llm.providers.huggingface.apiKey")).To(Equal("test-hf-key"))
+		})
+	})
+
+	Describe("Complex Configuration Scenarios", func() {
+		It("should handle comprehensive OAuth configuration", func() {
+			configContent := `
+database:
+  host: "localhost"
+  user: "testuser" 
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: true
+    clientId: "test-client"
+    clientSecret: "test-secret"
+    redirectUrl: "http://localhost:8080/callback"
+    authUrl: "http://auth.example.com/auth"
+    tokenUrl: "http://auth.example.com/token" 
+    userInfoUrl: "http://auth.example.com/userinfo"
+    jwksUrl: "http://auth.example.com/.well-known/jwks.json"
+    issuerUrl: "http://auth.example.com"
+    logoutUrl: "http://auth.example.com/logout"
+    scopes: 
+      - "openid"
+      - "profile" 
+      - "email"
+      - "groups"
+    adminUsers: 
+      - "admin@example.com"
+      - "superuser@example.com"
+    adminGroups: 
+      - "admins"
+      - "superusers"
+    adminGroupName: "administrators"
+    managerGroupName: "managers" 
+    userGroupName: "users"
+    userIdField: "user_id"
+    emailField: "user_email"
+    nameField: "display_name"
+    groupsField: "user_groups"
+    rolesField: "user_roles"
+`
+			err := os.WriteFile(configFile, []byte(configContent), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = manager.Load(configFile)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg := config.GetConfig()
+			oauth := cfg.Auth.OAuth
+			Expect(oauth.Enabled).To(BeTrue())
+			Expect(oauth.ClientID).To(Equal("test-client"))
+			Expect(oauth.ClientSecret).To(Equal("test-secret"))
+			Expect(oauth.RedirectURL).To(Equal("http://localhost:8080/callback"))
+			Expect(oauth.AdminUsers).To(ContainElements("admin@example.com", "superuser@example.com"))
+			Expect(oauth.AdminGroups).To(ContainElements("admins", "superusers"))
+			Expect(oauth.AdminGroupName).To(Equal("administrators"))
+			Expect(oauth.UserIDField).To(Equal("user_id"))
+			Expect(oauth.EmailField).To(Equal("user_email"))
+			Expect(oauth.NameField).To(Equal("display_name"))
+			Expect(oauth.GroupsField).To(Equal("user_groups"))
+			Expect(oauth.RolesField).To(Equal("user_roles"))
+		})
+
+		It("should handle OAuth role mappings configuration", func() {
+			// Test role mappings separately since they can be tricky with YAML parsing
+			configContent := `
+database:
+  host: "localhost"
+  user: "testuser" 
+  dbname: "testdb"
+auth:
+  enabled: true
+  oauth:
+    enabled: true
+    clientId: "test-client"
+    authUrl: "http://auth.example.com/auth"
+    tokenUrl: "http://auth.example.com/token"
+    redirectUrl: "http://localhost:8080/callback"
+`
+			err := os.WriteFile(configFile, []byte(configContent), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Set role mappings via environment variables to test that path
+			os.Setenv("OAUTH_ADMIN_USERS", "admin1@example.com,admin2@example.com")
+			os.Setenv("OAUTH_ADMIN_GROUPS", "admins,superusers")
+
+			err = manager.Load(configFile)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg := config.GetConfig()
+			oauth := cfg.Auth.OAuth
+			Expect(oauth.Enabled).To(BeTrue())
+			Expect(oauth.ClientID).To(Equal("test-client"))
+
+			// Note: Environment variables for lists are handled differently by viper
+			// The admin users and groups would be available through viper but may need
+			// custom parsing for comma-separated values
+		})
+
+		It("should handle comprehensive monitoring configuration", func() {
+			configContent := `
+database:
+  host: "localhost"
+  user: "testuser"
+  dbname: "testdb"  
+monitoring:
+  metrics:
+    enabled: true
+    path: "/custom-metrics"
+    port: 9091
+  tracing:
+    enabled: true
+    serviceName: "fern-platform"
+    endpoint: "http://jaeger:14268/api/traces"
+  health:
+    path: "/healthcheck"
+    interval: "45s"
+    timeout: "10s"
+`
+			err := os.WriteFile(configFile, []byte(configContent), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = manager.Load(configFile)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg := config.GetConfig()
+			monitoring := cfg.Monitoring
+			Expect(monitoring.Metrics.Enabled).To(BeTrue())
+			Expect(monitoring.Metrics.Path).To(Equal("/custom-metrics"))
+			Expect(monitoring.Metrics.Port).To(Equal(9091))
+			Expect(monitoring.Tracing.Enabled).To(BeTrue())
+			Expect(monitoring.Tracing.ServiceName).To(Equal("fern-platform"))
+			Expect(monitoring.Tracing.Endpoint).To(Equal("http://jaeger:14268/api/traces"))
+			Expect(monitoring.Health.Path).To(Equal("/healthcheck"))
+			Expect(monitoring.Health.Interval).To(Equal(45 * time.Second))
+			Expect(monitoring.Health.Timeout).To(Equal(10 * time.Second))
+		})
+	})
+})
+
+// Helper function to clear test environment variables
+func clearTestEnvVars() {
+	envVars := []string{
+		"PORT", "SERVER_PORT", "HOST", "SERVER_HOST",
+		"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME", "DB_SSLMODE",
+		"POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB", "POSTGRES_SSLMODE",
+		"AUTH_ENABLED", "JWT_SECRET", "JWKS_URL", "AUTH_ISSUER", "AUTH_AUDIENCE",
+		"OAUTH_ENABLED", "OAUTH_CLIENT_ID", "OAUTH_CLIENT_SECRET", "OAUTH_REDIRECT_URL",
+		"OAUTH_AUTH_URL", "OAUTH_TOKEN_URL", "OAUTH_USERINFO_URL", "OAUTH_JWKS_URL",
+		"OAUTH_ISSUER_URL", "OAUTH_LOGOUT_URL", "OAUTH_ADMIN_USERS", "OAUTH_ADMIN_GROUPS",
+		"OAUTH_USER_ID_FIELD", "OAUTH_EMAIL_FIELD", "OAUTH_NAME_FIELD", "OAUTH_GROUPS_FIELD", "OAUTH_ROLES_FIELD",
+		"OAUTH_ADMIN_GROUP_NAME", "OAUTH_MANAGER_GROUP_NAME", "OAUTH_USER_GROUP_NAME",
+		"REDIS_HOST", "REDIS_PORT", "REDIS_PASSWORD",
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "HUGGINGFACE_API_KEY",
+		"LOG_LEVEL", "LOG_FORMAT",
+	}
+
+	for _, envVar := range envVars {
+		os.Unsetenv(envVar)
+	}
+}
+
+var _ = Describe("Manager.Load with env vars", func() {
+	var m *config.Manager
+
+	BeforeEach(func() {
+		m = config.NewManager()
+	})
+
+	AfterEach(func() {
+		// clean up any env vars we set
+		_ = os.Unsetenv("SERVER_PORT")
+		_ = os.Unsetenv("DB_USER")
+		_ = os.Unsetenv("DB_PASS")
+	})
+
+	It("successfully binds SERVER_PORT env var", func() {
+		err := os.Setenv("SERVER_PORT", "9090")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Load with no config file, but env var set
+		err = m.Load("")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Viper should now resolve the value from env
+		Expect(m.GetString("server.port")).To(Equal("9090"))
+	})
+
+	It("returns error if config file is missing", func() {
+		// This triggers viper.ReadInConfig() error
+		missingFile := filepath.Join(os.TempDir(), "nonexistent-config.yaml")
+
+		err := m.Load(missingFile)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read config file"))
+	})
+
+	It("still works if multiple env vars are set", func() {
+		_ = os.Setenv("SERVER_PORT", "8081")
+		_ = os.Setenv("DB_USER", "testuser")
+		_ = os.Setenv("DB_PASS", "secret")
+
+		err := m.Load("")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(m.GetString("server.port")).To(Equal("8081"))
+		Expect(m.GetString("db.user")).To(Equal("testuser"))
+		Expect(m.GetString("db.pass")).To(Equal("secret"))
+	})
+})


### PR DESCRIPTION
#20 Added functionality to support authentication with external Identity Provider. Tested with Okta. 

Reference: 

https://github.com/user-attachments/assets/56ebf618-a005-4051-98e4-0c1bac1b489a


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for authentication using external Identity Providers, including OAuth and PKCE flows. Users can now log in with providers like Okta.

- **New Features**
 - Accepts OAuth tokens from Authorization headers or cookies.
 - Handles PKCE flow for providers that do not require a client secret.
 - Validates OAuth state and code verifier during login.
 - Updates config validation to allow OAuth without a client secret.

<!-- End of auto-generated description by cubic. -->

