### PR TITLE
feat: add timezone-aware Timestamp Component with formatting and hover tooltip functionality.

### DIFF
--- a/acceptance/timestamp/timestamp_component_test.go
+++ b/acceptance/timestamp/timestamp_component_test.go
@@ -2,7 +2,6 @@ package timestamp_test
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -192,17 +191,13 @@ var _ = Describe("Timestamp Component", Label("acceptance", "ui", "timestamp"), 
 			err = element.Hover()
 			Expect(err).NotTo(HaveOccurred())
 
-			// Wait a moment for the tooltip transition (300ms + buffer)
-			time.Sleep(500 * time.Millisecond)
-
-			// Check if tooltip becomes visible
-			tooltipVisible, err := page.Evaluate(`() => {
-				var tooltip = document.querySelector('#test-timestamp .timestamp-tooltip');
-				var computedStyle = window.getComputedStyle(tooltip);
-				return computedStyle.visibility === 'visible' || computedStyle.opacity > 0;
-			}`)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(tooltipVisible).To(Equal(true), "Tooltip should be visible on hover")
+			// Wait for tooltip to become visible using Playwright's wait functionality
+			tooltip := page.Locator("#test-timestamp .timestamp-tooltip")
+			err = tooltip.WaitFor(playwright.LocatorWaitForOptions{
+				State:   playwright.WaitForSelectorStateVisible,
+				Timeout: playwright.Float(2000), // 2 second timeout
+			})
+			Expect(err).NotTo(HaveOccurred(), "Tooltip should become visible on hover")
 		})
 	})
 

--- a/acceptance/timestamp/timestamp_component_test.go
+++ b/acceptance/timestamp/timestamp_component_test.go
@@ -1,0 +1,229 @@
+package timestamp_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/playwright-community/playwright-go"
+
+	"github.com/guidewire-oss/fern-platform/acceptance/helpers"
+)
+
+var _ = Describe("Timestamp Component", Label("acceptance", "ui", "timestamp"), func() {
+	var (
+		browser playwright.Browser
+		ctx     playwright.BrowserContext
+		page    playwright.Page
+		auth    *helpers.LoginHelper
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a new browser for each test
+		browser = CreateBrowser()
+
+		// Create browser context options
+		contextOptions := playwright.BrowserNewContextOptions{
+			BaseURL: playwright.String(baseURL),
+		}
+
+		// Add video recording if enabled
+		if recordVideo {
+			contextOptions.RecordVideo = &playwright.RecordVideo{
+				Dir:  "./videos",
+				Size: &playwright.Size{Width: 1280, Height: 720},
+			}
+		}
+
+		ctx, err = browser.NewContext(contextOptions)
+		Expect(err).NotTo(HaveOccurred())
+
+		page, err = ctx.NewPage()
+		Expect(err).NotTo(HaveOccurred())
+
+		auth = helpers.NewLoginHelper(page, baseURL, username, password)
+		auth.Login()
+	})
+
+	AfterEach(func() {
+		if page != nil {
+			page.Close()
+		}
+		if ctx != nil {
+			ctx.Close()
+		}
+		if browser != nil {
+			browser.Close()
+		}
+	})
+
+	Context("Component Loading", func() {
+		It("should load TimestampComponent globally", func() {
+			// Execute JavaScript to check if component is loaded
+			result, err := page.Evaluate("typeof window.TimestampComponent !== 'undefined'")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(true), "TimestampComponent should be available globally")
+		})
+
+		It("should have required methods available", func() {
+			script := `() => {
+				return window.TimestampComponent && 
+				       typeof window.TimestampComponent.formatTimestamp === 'function' &&
+				       typeof window.TimestampComponent.createElement === 'function' &&
+				       typeof window.TimestampComponent.createRelativeElement === 'function';
+			}`
+			result, err := page.Evaluate(script)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(true), "TimestampComponent should have all required methods")
+		})
+	})
+
+	Context("Timestamp Formatting", func() {
+		It("should format timestamps correctly", func() {
+			testTimestamp := "2025-01-25T14:30:00Z"
+			script := fmt.Sprintf(`() => {
+				var result = window.TimestampComponent.formatTimestamp('%s');
+				return {
+					hasLocalFormatted: !!result.localFormatted,
+					hasUtcFormatted: !!result.utcFormatted,
+					localLength: result.localFormatted.length,
+					utcLength: result.utcFormatted.length
+				};
+			}`, testTimestamp)
+
+			result, err := page.Evaluate(script)
+			Expect(err).NotTo(HaveOccurred())
+
+			resultMap := result.(map[string]interface{})
+			Expect(resultMap["hasLocalFormatted"]).To(Equal(true))
+			Expect(resultMap["hasUtcFormatted"]).To(Equal(true))
+			Expect(resultMap["localLength"]).To(BeNumerically(">", 10))
+			Expect(resultMap["utcLength"]).To(BeNumerically(">", 10))
+		})
+
+		It("should handle different timezone inputs", func() {
+			testCases := []string{
+				"2025-01-25T14:30:00Z",      // UTC
+				"2025-01-25T09:30:00-05:00", // EST
+				"2025-01-25T06:30:00-08:00", // PST
+			}
+
+			for _, testCase := range testCases {
+				script := fmt.Sprintf(`() => {
+					try {
+						var result = window.TimestampComponent.formatTimestamp('%s');
+						return { success: true, hasData: !!result.localFormatted };
+					} catch (error) {
+						return { success: false, error: error.message };
+					}
+				}`, testCase)
+
+				result, err := page.Evaluate(script)
+				Expect(err).NotTo(HaveOccurred())
+
+				resultMap := result.(map[string]interface{})
+				Expect(resultMap["success"]).To(Equal(true), fmt.Sprintf("Failed for timestamp: %s", testCase))
+				Expect(resultMap["hasData"]).To(Equal(true))
+			}
+		})
+	})
+
+	Context("DOM Element Creation", func() {
+		It("should create timestamp DOM elements", func() {
+			script := `() => {
+				var element = window.TimestampComponent.createElement('2025-01-25T14:30:00Z');
+				document.body.appendChild(element);
+				return {
+					hasWrapper: element.classList.contains('timestamp-wrapper'),
+					hasTooltip: !!element.querySelector('.timestamp-tooltip'),
+					hasIcon: !!element.querySelector('.timestamp-icon')
+				};
+			}`
+
+			result, err := page.Evaluate(script)
+			Expect(err).NotTo(HaveOccurred())
+
+			resultMap := result.(map[string]interface{})
+			Expect(resultMap["hasWrapper"]).To(Equal(true))
+			Expect(resultMap["hasTooltip"]).To(Equal(true))
+			Expect(resultMap["hasIcon"]).To(Equal(true))
+		})
+
+		It("should create relative timestamp elements", func() {
+			script := `() => {
+				var pastTime = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 minutes ago
+				var element = window.TimestampComponent.createRelativeElement(pastTime);
+				document.body.appendChild(element);
+				return {
+					hasWrapper: element.classList.contains('timestamp-wrapper'),
+					textContent: element.querySelector('.timestamp-local').textContent,
+					hasTooltip: !!element.querySelector('.timestamp-tooltip')
+				};
+			}`
+
+			result, err := page.Evaluate(script)
+			Expect(err).NotTo(HaveOccurred())
+
+			resultMap := result.(map[string]interface{})
+			Expect(resultMap["hasWrapper"]).To(Equal(true))
+			Expect(resultMap["textContent"]).To(ContainSubstring("minute"))
+			Expect(resultMap["hasTooltip"]).To(Equal(true))
+		})
+	})
+
+	Context("Hover Functionality", func() {
+		It("should show tooltip on hover", func() {
+			// Create a timestamp element
+			_, err := page.Evaluate(`() => {
+				var element = window.TimestampComponent.createElement('2025-01-25T14:30:00Z');
+				element.id = 'test-timestamp';
+				document.body.appendChild(element);
+			}`)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Find the element and hover over it
+			element, err := page.QuerySelector("#test-timestamp")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Hover over the element to trigger tooltip
+			err = element.Hover()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait a moment for the tooltip transition (300ms + buffer)
+			time.Sleep(500 * time.Millisecond)
+
+			// Check if tooltip becomes visible
+			tooltipVisible, err := page.Evaluate(`() => {
+				var tooltip = document.querySelector('#test-timestamp .timestamp-tooltip');
+				var computedStyle = window.getComputedStyle(tooltip);
+				return computedStyle.visibility === 'visible' || computedStyle.opacity > 0;
+			}`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tooltipVisible).To(Equal(true), "Tooltip should be visible on hover")
+		})
+	})
+
+	Context("Timezone Information", func() {
+		It("should provide user timezone info", func() {
+			script := `() => {
+				var info = window.TimestampComponent.getTimezoneInfo();
+				return {
+					hasTimeZone: !!info.timeZone,
+					hasTimeZoneName: !!info.timeZoneName,
+					hasOffset: typeof info.offset === 'number'
+				};
+			}`
+
+			result, err := page.Evaluate(script)
+			Expect(err).NotTo(HaveOccurred())
+
+			resultMap := result.(map[string]interface{})
+			Expect(resultMap["hasTimeZone"]).To(Equal(true))
+			Expect(resultMap["hasTimeZoneName"]).To(Equal(true))
+			Expect(resultMap["hasOffset"]).To(Equal(true))
+		})
+	})
+})

--- a/acceptance/timestamp/timestamp_suite_test.go
+++ b/acceptance/timestamp/timestamp_suite_test.go
@@ -1,0 +1,129 @@
+package timestamp_test
+
+import (
+	"flag"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/playwright-community/playwright-go"
+)
+
+var (
+	// Configuration flags
+	baseURL     string
+	headless    bool
+	slowMo      float64
+	username    string
+	password    string
+	recordVideo bool
+
+	// Playwright objects
+	pw *playwright.Playwright
+)
+
+func init() {
+	flag.StringVar(&baseURL, "base-url", getEnvOrDefault("FERN_BASE_URL", "http://fern-platform.local:8080"), "Base URL for Fern Platform")
+	flag.BoolVar(&headless, "headless", getEnvOrDefault("FERN_HEADLESS", "true") == "true", "Run browser in headless mode")
+	flag.Float64Var(&slowMo, "slow-mo", 0, "Slow motion delay in milliseconds")
+	flag.StringVar(&username, "username", getEnvOrDefault("FERN_USERNAME", "fern-manager@fern.com"), "Username for authentication")
+	flag.StringVar(&password, "password", getEnvOrDefault("FERN_PASSWORD", "test123"), "Password for authentication")
+	flag.BoolVar(&recordVideo, "record-video", getEnvOrDefault("FERN_RECORD_VIDEO", "false") == "true", "Record videos of test runs")
+}
+
+func TestTimestamp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Timestamp Component Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// Install playwright browsers if needed
+	err = playwright.Install()
+	Expect(err).NotTo(HaveOccurred())
+
+	// Initialize playwright
+	pw, err = playwright.Run()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if pw != nil {
+		defer func() {
+			recover()
+		}()
+		pw.Stop()
+	}
+})
+
+// Helper function to get environment variable with default
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// CreateBrowser creates a new browser instance
+func CreateBrowser() playwright.Browser {
+	args := []string{
+		"--disable-blink-features=AutomationControlled",
+		"--no-sandbox",
+		"--disable-setuid-sandbox",
+		"--disable-dev-shm-usage",
+		"--disable-gpu",
+		"--disable-web-security",
+		"--disable-features=IsolateOrigins,site-per-process",
+		"--disable-accelerated-2d-canvas",
+		"--disable-audio-output",
+	}
+
+	// Add platform-specific args
+	if runtime.GOOS == "darwin" {
+		// Mac-specific: helps with TLS certificate issues
+		args = append(args, "--single-process", "--no-zygote")
+	} else if isRunningInDocker() {
+		// Docker/CI-specific: additional stability flags
+		args = append(args,
+			"--disable-background-timer-throttling",
+			"--disable-backgrounding-occluded-windows",
+			"--disable-renderer-backgrounding",
+		)
+	}
+
+	// Allow CI to override with custom args
+	if customArgs := os.Getenv("PLAYWRIGHT_CHROMIUM_ARGS"); customArgs != "" {
+		extraArgs := strings.Split(customArgs, " ")
+		args = append(args, extraArgs...)
+	}
+
+	// Log browser launch args in verbose mode
+	if os.Getenv("DEBUG") != "" {
+		GinkgoWriter.Printf("Launching Chromium with args: %v\n", args)
+	}
+
+	browser, err := pw.Chromium.Launch(playwright.BrowserTypeLaunchOptions{
+		Headless: playwright.Bool(headless),
+		SlowMo:   playwright.Float(slowMo),
+		Args:     args,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return browser
+}
+
+// isRunningInDocker checks if we're running inside a Docker container
+func isRunningInDocker() bool {
+	// Check for .dockerenv file
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	// Check for Docker in cgroup
+	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+		return strings.Contains(string(data), "docker") || strings.Contains(string(data), "containerd")
+	}
+	return false
+}

--- a/acceptance/timestamp/timestamp_suite_test.go
+++ b/acceptance/timestamp/timestamp_suite_test.go
@@ -54,9 +54,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	if pw != nil {
 		defer func() {
-			recover()
+			if r := recover(); r != nil {
+				GinkgoWriter.Printf("Warning: panic during Playwright shutdown: %v\n", r)
+			}
 		}()
-		pw.Stop()
+		if err := pw.Stop(); err != nil {
+			GinkgoWriter.Printf("Warning: error stopping Playwright: %v\n", err)
+		}
 	}
 })
 
@@ -97,7 +101,7 @@ func CreateBrowser() playwright.Browser {
 
 	// Allow CI to override with custom args
 	if customArgs := os.Getenv("PLAYWRIGHT_CHROMIUM_ARGS"); customArgs != "" {
-		extraArgs := strings.Split(customArgs, " ")
+		extraArgs := parseShellArgs(customArgs)
 		args = append(args, extraArgs...)
 	}
 
@@ -126,4 +130,52 @@ func isRunningInDocker() bool {
 		return strings.Contains(string(data), "docker") || strings.Contains(string(data), "containerd")
 	}
 	return false
+}
+
+// parseShellArgs parses shell-style arguments, handling quotes and escapes properly
+func parseShellArgs(input string) []string {
+	var args []string
+	var current strings.Builder
+	var inQuotes bool
+	var quoteChar rune
+	
+	runes := []rune(input)
+	for i := 0; i < len(runes); i++ {
+		char := runes[i]
+		
+		switch {
+		case !inQuotes && (char == '"' || char == '\''):
+			// Start quoted section
+			inQuotes = true
+			quoteChar = char
+		case inQuotes && char == quoteChar:
+			// End quoted section
+			inQuotes = false
+			quoteChar = 0
+		case !inQuotes && (char == ' ' || char == '\t'):
+			// Whitespace outside quotes - end current arg
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+			// Skip consecutive whitespace
+			for i+1 < len(runes) && (runes[i+1] == ' ' || runes[i+1] == '\t') {
+				i++
+			}
+		case char == '\\' && i+1 < len(runes):
+			// Escape sequence
+			i++
+			current.WriteRune(runes[i])
+		default:
+			// Regular character
+			current.WriteRune(char)
+		}
+	}
+	
+	// Add final argument if any
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+	
+	return args
 }

--- a/web/index.html
+++ b/web/index.html
@@ -2116,19 +2116,22 @@
         // Timestamp React Component wrapper for timezone-aware display
         const Timestamp = ({ timestamp, options = {} }) => {
             const [element, setElement] = useState(null);
+            
+            // Memoize options to prevent infinite re-renders
+            const memoizedOptions = useMemo(() => options, [JSON.stringify(options)]);
 
             useEffect(() => {
                 if (!timestamp || !window.TimestampComponent) return;
                 
                 try {
-                    const timestampElement = window.TimestampComponent.createElement(timestamp, options);
+                    const timestampElement = window.TimestampComponent.createElement(timestamp, memoizedOptions);
                     setElement(timestampElement);
                 } catch (error) {
                     console.error('Error creating timestamp element:', error);
                     // Fallback to formatDate
                     setElement(null);
                 }
-            }, [timestamp, options]);
+            }, [timestamp, memoizedOptions]);
 
             if (!element) {
                 return <span>{formatDate(timestamp)}</span>;

--- a/web/index.html
+++ b/web/index.html
@@ -16,6 +16,7 @@
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="/web/js/graphql-client.js?v=5"></script>
+    <script src="/web/js/timestamp-component.js?v=2"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link href="/web/css/font-awesome.min.css" rel="stylesheet">
     
@@ -2112,6 +2113,35 @@
             });
         };
 
+        // Timestamp React Component wrapper for timezone-aware display
+        const Timestamp = ({ timestamp, options = {} }) => {
+            const [element, setElement] = useState(null);
+
+            useEffect(() => {
+                if (!timestamp || !window.TimestampComponent) return;
+                
+                try {
+                    const timestampElement = window.TimestampComponent.createElement(timestamp, options);
+                    setElement(timestampElement);
+                } catch (error) {
+                    console.error('Error creating timestamp element:', error);
+                    // Fallback to formatDate
+                    setElement(null);
+                }
+            }, [timestamp, options]);
+
+            if (!element) {
+                return <span>{formatDate(timestamp)}</span>;
+            }
+
+            return <span ref={node => {
+                if (node && element) {
+                    node.innerHTML = '';
+                    node.appendChild(element);
+                }
+            }} />;
+        };
+
         const getTestStatusColor = (passed, failed, skipped, total) => {
             if (total === 0) return '#6b7280';
             
@@ -3820,7 +3850,7 @@
                             <div className="stat-row">
                                 <span style={{fontWeight: '500'}}>Last Updated</span>
                                 <span style={{fontWeight: '600', color: 'var(--text-secondary)'}}>
-                                    {health?.timestamp ? formatDate(health.timestamp) : 'N/A'}
+                                    {health?.timestamp ? <Timestamp timestamp={health.timestamp} /> : 'N/A'}
                                 </span>
                             </div>
                         </div>
@@ -4952,7 +4982,7 @@
                                                 <td style={{fontWeight: '500'}}>
                                                     {run.duration ? `${(run.duration / 1000).toFixed(1)}s` : 'N/A'}
                                                 </td>
-                                                <td style={{fontWeight: '500', color: 'var(--text-secondary)'}}>{formatDate(run.startTime)}</td>
+                                                <td style={{fontWeight: '500', color: 'var(--text-secondary)'}}><Timestamp timestamp={run.startTime} /></td>
                                             </tr>
                                         ))}
                                     </tbody>
@@ -5085,7 +5115,7 @@
                                                     <span style={{color: 'var(--text-tertiary)', fontSize: '0.875rem'}}>-</span>
                                                 )}
                                             </td>
-                                            <td style={{fontWeight: '500', color: 'var(--text-secondary)'}}>{formatDate(spec.startTime || spec.started_at)}</td>
+                                            <td style={{fontWeight: '500', color: 'var(--text-secondary)'}}><Timestamp timestamp={spec.startTime || spec.started_at} /></td>
                                         </tr>
                                     ))}
                                 </tbody>
@@ -6850,7 +6880,7 @@
                                                     }}>Last Tested</span>
                                                     <p style={{ margin: '0.5rem 0 0 0', fontSize: '0.875rem' }}>
                                                         <i className="fas fa-clock" style={{ marginRight: '0.5rem', color: 'var(--text-secondary)' }}></i>
-                                                        {connection.lastTestedAt ? formatDate(new Date(connection.lastTestedAt)) : 'Never'}
+                                                        {connection.lastTestedAt ? <Timestamp timestamp={new Date(connection.lastTestedAt)} /> : 'Never'}
                                                     </p>
                                                 </div>
                                             </div>

--- a/web/js/timestamp-component.js
+++ b/web/js/timestamp-component.js
@@ -1,0 +1,287 @@
+// Timezone-aware Timestamp Component for Fern Platform
+// Displays timestamps in local timezone with UTC hover tooltip
+
+class TimestampComponent {
+    constructor() {
+        this.userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        this.initializeStyles();
+    }
+
+    initializeStyles() {
+        // Add styles for the component if they don't exist
+        if (!document.getElementById('timestamp-component-styles')) {
+            const style = document.createElement('style');
+            style.id = 'timestamp-component-styles';
+            style.textContent = `
+                .timestamp-wrapper {
+                    position: relative;
+                    display: inline-block;
+                    cursor: help;
+                }
+
+                .timestamp-local {
+                    color: inherit;
+                    font-family: inherit;
+                }
+
+                .timestamp-icon {
+                    margin-left: 4px;
+                    opacity: 0.6;
+                    font-size: 0.85em;
+                    color: var(--text-muted, #6b7280);
+                }
+
+                .timestamp-tooltip {
+                    position: absolute;
+                    top: -35px;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    background: rgba(0, 0, 0, 0.9);
+                    color: white;
+                    padding: 6px 12px;
+                    border-radius: 6px;
+                    font-size: 12px;
+                    white-space: nowrap;
+                    opacity: 0;
+                    visibility: hidden;
+                    transition: opacity 0.3s, visibility 0.3s;
+                    z-index: 1000;
+                    pointer-events: none;
+                }
+
+                .timestamp-tooltip::after {
+                    content: '';
+                    position: absolute;
+                    top: 100%;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    border: 5px solid transparent;
+                    border-top-color: rgba(0, 0, 0, 0.9);
+                }
+
+                .timestamp-wrapper:hover .timestamp-tooltip {
+                    opacity: 1;
+                    visibility: visible;
+                    transition-delay: 300ms;
+                }
+            `;
+            document.head.appendChild(style);
+        }
+    }
+
+    /**
+     * Format a timestamp for display in local timezone
+     * @param {string|Date} timestamp - ISO timestamp or Date object
+     * @param {Object} options - Formatting options
+     * @returns {Object} - Object with localFormatted and utcFormatted strings
+     */
+    formatTimestamp(timestamp, options = {}) {
+        const {
+            includeSeconds = true,
+            includeDateIfDifferent = true,
+            shortFormat = false
+        } = options;
+
+        let date;
+        if (typeof timestamp === 'string') {
+            date = new Date(timestamp);
+        } else if (timestamp instanceof Date) {
+            date = timestamp;
+        } else {
+            throw new Error('Invalid timestamp format');
+        }
+
+        if (isNaN(date.getTime())) {
+            throw new Error('Invalid date');
+        }
+
+        // Format for local timezone
+        const localOptions = {
+            year: 'numeric',
+            month: shortFormat ? 'short' : 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'short'
+        };
+
+        if (includeSeconds) {
+            localOptions.second = '2-digit';
+        }
+
+        const localFormatted = new Intl.DateTimeFormat('en-US', {
+            ...localOptions,
+            timeZone: this.userTimezone
+        }).format(date);
+
+        // Format for UTC tooltip
+        const utcFormatted = new Intl.DateTimeFormat('en-US', {
+            ...localOptions,
+            timeZone: 'UTC',
+            timeZoneName: 'short'
+        }).format(date);
+
+        return { localFormatted, utcFormatted };
+    }
+
+    /**
+     * Create a DOM element with timezone-aware timestamp display
+     * @param {string|Date} timestamp - ISO timestamp or Date object
+     * @param {Object} options - Formatting and display options
+     * @returns {HTMLElement} - DOM element with timestamp and hover tooltip
+     */
+    createElement(timestamp, options = {}) {
+        const { localFormatted, utcFormatted } = this.formatTimestamp(timestamp, options);
+
+        const wrapper = document.createElement('span');
+        wrapper.className = 'timestamp-wrapper';
+
+        const timestampSpan = document.createElement('span');
+        timestampSpan.className = 'timestamp-local';
+        timestampSpan.textContent = localFormatted;
+
+        const icon = document.createElement('span');
+        icon.className = 'timestamp-icon';
+        icon.innerHTML = '🌍';
+        icon.setAttribute('aria-hidden', 'true');
+
+        const tooltip = document.createElement('div');
+        tooltip.className = 'timestamp-tooltip';
+        tooltip.textContent = `UTC: ${utcFormatted}`;
+        tooltip.setAttribute('role', 'tooltip');
+
+        wrapper.appendChild(timestampSpan);
+        wrapper.appendChild(icon);
+        wrapper.appendChild(tooltip);
+
+        // Add ARIA attributes for accessibility
+        wrapper.setAttribute('aria-label', `Local time: ${localFormatted}, UTC time: ${utcFormatted}`);
+        wrapper.setAttribute('tabindex', '0');
+
+        return wrapper;
+    }
+
+    /**
+     * Replace all timestamps in a container with timezone-aware components
+     * @param {HTMLElement} container - Container element to search for timestamps
+     * @param {string} selector - CSS selector for timestamp elements
+     * @param {Object} options - Formatting options
+     */
+    replaceTimestampsInContainer(container, selector = '[data-timestamp]', options = {}) {
+        const timestampElements = container.querySelectorAll(selector);
+        
+        timestampElements.forEach(element => {
+            const timestamp = element.dataset.timestamp || element.textContent.trim();
+            if (timestamp) {
+                try {
+                    const newElement = this.createElement(timestamp, options);
+                    element.parentNode.replaceChild(newElement, element);
+                } catch (error) {
+                    console.warn('Failed to parse timestamp:', timestamp, error);
+                }
+            }
+        });
+    }
+
+    /**
+     * Format a relative time (e.g., "2 hours ago") with timezone awareness
+     * @param {string|Date} timestamp - ISO timestamp or Date object
+     * @returns {Object} - Object with relative time and tooltip
+     */
+    formatRelativeTime(timestamp) {
+        const date = new Date(timestamp);
+        const now = new Date();
+        const diffMs = now - date;
+        const diffMinutes = Math.floor(diffMs / (1000 * 60));
+        const diffHours = Math.floor(diffMinutes / 60);
+        const diffDays = Math.floor(diffHours / 24);
+
+        let relativeText;
+        if (diffMinutes < 1) {
+            relativeText = 'Just now';
+        } else if (diffMinutes < 60) {
+            relativeText = `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+        } else if (diffHours < 24) {
+            relativeText = `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+        } else if (diffDays < 7) {
+            relativeText = `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+        } else {
+            const { localFormatted } = this.formatTimestamp(timestamp, { shortFormat: true });
+            relativeText = localFormatted;
+        }
+
+        const { localFormatted, utcFormatted } = this.formatTimestamp(timestamp);
+        
+        return {
+            relativeText,
+            localFormatted,
+            utcFormatted
+        };
+    }
+
+    /**
+     * Create a relative timestamp element
+     * @param {string|Date} timestamp - ISO timestamp or Date object
+     * @returns {HTMLElement} - DOM element with relative time and hover tooltip
+     */
+    createRelativeElement(timestamp) {
+        const { relativeText, localFormatted, utcFormatted } = this.formatRelativeTime(timestamp);
+
+        const wrapper = document.createElement('span');
+        wrapper.className = 'timestamp-wrapper';
+
+        const timestampSpan = document.createElement('span');
+        timestampSpan.className = 'timestamp-local';
+        timestampSpan.textContent = relativeText;
+
+        const icon = document.createElement('span');
+        icon.className = 'timestamp-icon';
+        icon.innerHTML = '🕐';
+        icon.setAttribute('aria-hidden', 'true');
+
+        const tooltip = document.createElement('div');
+        tooltip.className = 'timestamp-tooltip';
+        tooltip.innerHTML = `Local: ${localFormatted}<br>UTC: ${utcFormatted}`;
+        tooltip.setAttribute('role', 'tooltip');
+
+        wrapper.appendChild(timestampSpan);
+        wrapper.appendChild(icon);
+        wrapper.appendChild(tooltip);
+
+        // Add ARIA attributes for accessibility
+        wrapper.setAttribute('aria-label', `${relativeText}, Local time: ${localFormatted}, UTC time: ${utcFormatted}`);
+        wrapper.setAttribute('tabindex', '0');
+
+        return wrapper;
+    }
+
+    /**
+     * Get user's timezone information
+     * @returns {Object} - Timezone information
+     */
+    getTimezoneInfo() {
+        const timeZone = this.userTimezone;
+        const now = new Date();
+        const formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone,
+            timeZoneName: 'short'
+        });
+        
+        const parts = formatter.formatToParts(now);
+        const timeZoneName = parts.find(part => part.type === 'timeZoneName')?.value || timeZone;
+
+        return {
+            timeZone,
+            timeZoneName,
+            offset: -now.getTimezoneOffset() / 60
+        };
+    }
+}
+
+// Create global instance
+window.TimestampComponent = new TimestampComponent();
+
+// Export for module usage if needed
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = TimestampComponent;
+}

--- a/web/js/timestamp-component.js
+++ b/web/js/timestamp-component.js
@@ -9,7 +9,8 @@ class TimestampComponent {
 
     initializeStyles() {
         // Add styles for the component if they don't exist
-        if (!document.getElementById('timestamp-component-styles')) {
+        // Guard against SSR/Node contexts where document is undefined
+        if (typeof window === 'undefined' || !document.getElementById('timestamp-component-styles')) {
             const style = document.createElement('style');
             style.id = 'timestamp-component-styles';
             style.textContent = `
@@ -78,7 +79,6 @@ class TimestampComponent {
     formatTimestamp(timestamp, options = {}) {
         const {
             includeSeconds = true,
-            includeDateIfDifferent = true,
             shortFormat = false
         } = options;
 
@@ -278,8 +278,10 @@ class TimestampComponent {
     }
 }
 
-// Create global instance
-window.TimestampComponent = new TimestampComponent();
+// Create global instance with SSR compatibility
+if (typeof window !== 'undefined') {
+    window.TimestampComponent = new TimestampComponent();
+}
 
 // Export for module usage if needed
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
Created for issue: https://github.com/guidewire-oss/fern-platform/issues/34
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a timezone-aware Timestamp component that shows local time with UTC on hover, and replaces several date displays across the UI for consistency. Addresses issue #34 by making timestamps clearer and standardized.

- **New Features**
  - New global TimestampComponent (web/js/timestamp-component.js): local and UTC formatting, relative time, hover tooltip, ARIA labels.
  - Lightweight CSS-in-JS styles; no new dependencies.
  - React wrapper <Timestamp> added in index.html for easy use.
  - Replaced date renders with <Timestamp> in:
    - Health “Last Updated”
    - Test Runs “Start Time”
    - Specs “Start Time”
    - Connections “Last Tested”
  - Acceptance tests (Playwright + Ginkgo) validate: component load, formatting across timezones, DOM creation, relative timestamps, hover tooltip visibility, and timezone info.

<!-- End of auto-generated description by cubic. -->

