### PR TITLE
fix: add missing import usememo

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1574,7 +1574,7 @@
 
     <script type="text/babel">
         // Destructure React hooks at the top level
-        const { useState, useEffect, useRef, useCallback } = React;
+        const { useState, useEffect, useRef, useCallback, useMemo } = React;
         
         // Make GraphQL queries available globally
         const GRAPHQL_QUERIES = window.GRAPHQL_QUERIES;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added missing useMemo to React hook destructuring in web/index.html. Prevents “useMemo is not defined” runtime errors and ensures memoization works where used.

<!-- End of auto-generated description by cubic. -->

