### PR TITLE
refactor(ci): skip builds for non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,20 @@ on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
 
 # NOTE: If your enterprise restricts GITHUB_TOKEN permissions,
 # create a Personal Access Token (PAT) with 'repo' and 'write:packages' scopes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     tags: [ 'v*' ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'
@@ -12,6 +14,8 @@ on:
   pull_request:
     branches: [ main ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
     tags: [ 'v*' ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'
@@ -13,7 +12,6 @@ on:
   pull_request:
     branches: [ main ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,20 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ "main" ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'
@@ -11,6 +13,8 @@ on:
   pull_request:
     branches: [ "main" ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'
@@ -12,7 +11,6 @@ on:
   pull_request:
     branches: [ "main" ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,12 @@ name: PR Validation
 on:
   pull_request:
     types: [opened, edited, synchronize]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   validate-pr:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches: [ "main" ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,12 @@ on:
     - cron: '30 1 * * 6'
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches: [ "main" ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,20 @@ name: Security Checks
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '.github/**'
+      - '.slsa-goreleaser/**'
+      - '.gitignore'
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron: '0 0 * * 1' # Weekly on Monday
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'
@@ -12,7 +11,6 @@ on:
   pull_request:
     branches: [ main ]
     paths-ignore:
-      - '.github/**'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'
@@ -11,6 +13,8 @@ on:
   pull_request:
     branches: [ main ]
     paths-ignore:
+      - '.github/CODEOWNERS'
+      - '.github/SECURITY.md'
       - '.slsa-goreleaser/**'
       - '.gitignore'
       - 'docs/**'


### PR DESCRIPTION
#90 

Add paths-ignore filters to GitHub workflows to prevent unnecessary CI runs when only non-code files are modified:

- .slsa-goreleaser/** (SLSA goreleaser files)
- .gitignore (Git ignore file)
- docs/** (Documentation files)
- **.md (Markdown files)

Updated workflows:
- ci.yml (main CI/CD pipeline)
- pr-validation.yml (PR validation)
- codeql.yml (CodeQL security analysis)
- security.yml (security checks)
- scorecard.yml (OpenSSF scorecard)

This optimization reduces CI resource usage 
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip CI runs for non-code changes by adding paths-ignore to key GitHub Actions. This cuts CI noise and saves resources without affecting code checks.

- **Refactors**
  - Added paths-ignore for .github/**, .slsa-goreleaser/**, .gitignore, docs/**, and **.md.
  - Updated workflows: ci.yml, pr-validation.yml, codeql.yml, security.yml, scorecard.yml.
  - Applied to push and pull_request triggers.

<!-- End of auto-generated description by cubic. -->

