### PR TITLE
fix: fixed first time startup issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ bin/fern-platform
 # Temporary Dockerfile created by Makefile
 Dockerfile.fern-platform
 
+# ide
+*.idea
+
 # Git files
 .git-authors
 

--- a/migrations/000015_create_jira_connections_table.up.sql
+++ b/migrations/000015_create_jira_connections_table.up.sql
@@ -45,6 +45,5 @@ COMMENT ON COLUMN jira_connections.is_active IS 'Whether the connection is activ
 COMMENT ON COLUMN jira_connections.last_tested_at IS 'Timestamp of last connection test';
 COMMENT ON COLUMN jira_connections.deleted_at IS 'Soft delete timestamp';
 
--- Grant permissions to app user
-ALTER TABLE jira_connections OWNER TO app;
-GRANT ALL PRIVILEGES ON TABLE jira_connections TO app;
+-- Note: Table ownership and privileges are handled by the database connection user
+-- The table will be owned by the user running the migration (configured in config.yaml)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix first-time startup by removing hard-coded table owner/privilege statements in the Jira connections migration to avoid permission errors on fresh installs. Also added IDE files (*.idea) to .gitignore.

- **Bug Fixes**
  - Removed ALTER OWNER and GRANT from migration 000015; table ownership now comes from the migration user set in config.yaml.

<!-- End of auto-generated description by cubic. -->

