### PR TITLE
feat: add slug for fern-platform #107

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,3 +206,4 @@ jobs:
           flags: unittests
           name: main-coverage
           fail_ci_if_error: false
+          slug: guidewire-oss/fern-platform


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set the Codecov slug in CI to guidewire-oss/fern-platform so coverage uploads are attributed to the correct repo. Prevents incorrect coverage reporting for fern-platform.

<!-- End of auto-generated description by cubic. -->

