### PR TITLE
feat: remove slug #107

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,4 +206,3 @@ jobs:
           flags: unittests
           name: main-coverage
           fail_ci_if_error: false
-          slug: guidewire-oss/fern-platform


### PR DESCRIPTION
Adding the slug did not fix the issue with codecov. The token has now been updated but we get 
```
Upload failed: {"message":"Repository not found"}
```
so remove the slug and allow the repo to come from the token.