### PR TITLE
fix: reinstate web redirect

### DIFF
--- a/internal/api/domain_handler.go
+++ b/internal/api/domain_handler.go
@@ -60,6 +60,11 @@ func NewDomainHandler(
 
 // RegisterRoutes registers all domain handler routes
 func (h *DomainHandler) RegisterRoutes(router *gin.Engine) {
+	// Root route - redirect to web interface
+	router.GET("/", func(c *gin.Context) {
+		c.Redirect(http.StatusMovedPermanently, "/web/")
+	})
+
 	// Health check route
 	router.GET("/health", h.healthCheck)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reinstates the root path redirect to /web/ so hitting / sends users to the web UI. Satisfies Linear #114’s requirement to default the API root to the web interface.

<sup>Written for commit 39377df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

