### PR TITLE
feat: Use automatic GITHUB_TOKEN for GHCR publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GH_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v3


### PR DESCRIPTION
Let github automatically get the acting user's token for authentication. Only users with WRITE permission will be able to run the `release` job.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update release workflow to authenticate to ghcr.io with the GitHub-provided GITHUB_TOKEN instead of GH_PAT. This uses the actor’s token and limits running the release job to users with write permission.

<sup>Written for commit 0620b5b8f217774b84133a9abc127f6d392d31e3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



