### PR TITLE
feat: Use automatic GITHUB_TOKEN for GHCR publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GH_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched GHCR authentication in the release workflow to use the built-in GITHUB_TOKEN instead of GH_PAT. This simplifies secret management and aligns with GitHub Actions recommended auth for publishing to ghcr.io.

<sup>Written for commit 0620b5b8f217774b84133a9abc127f6d392d31e3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

