### PR TITLE
feat: use automatic GITHUB_TOKEN for GHCR publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GH_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v3


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch GHCR login in the release workflow to use the automatic GITHUB_TOKEN instead of a personal GH_PAT. This simplifies setup, improves security, and fixes auth issues when pushing images to ghcr.io.

<sup>Written for commit 1ae7e5b9bf2329fc506cb6e9d8a88ebc8b97f10f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



