### PR TITLE
fix: remove duplicate root redirect to web, add mockgen to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,9 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Install mockgen
+      run: go install github.com/golang/mock/mockgen@v1.6.0
+
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/internal/api/domain_handler.go
+++ b/internal/api/domain_handler.go
@@ -147,9 +147,6 @@ func (h *DomainHandler) RegisterRoutes(router *gin.Engine) {
 
 	// Static file serving
 	router.Static("/web", "./web")
-	router.GET("/", func(c *gin.Context) {
-		c.Redirect(http.StatusMovedPermanently, "/web/")
-	})
 }
 
 // Helper function to check if user is authenticated


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the duplicate root (/) redirect to /web to prevent double redirects. Updated the release workflow to install mockgen v1.6.0 so releases build correctly with generated mocks.

<sup>Written for commit e4b4cb7627c8c208bb89347a017e551646e3b44e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

