### PR TITLE
fix: bind auth introspection values to viper

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -380,6 +380,15 @@ func (m *Manager) bindEnvVars() error {
 	if err := viper.BindEnv("auth.oauth.logoutUrl", "OAUTH_LOGOUT_URL"); err != nil {
 		return err
 	}
+	if err := viper.BindEnv("auth.oauth.introspectionUrl", "OAUTH_INTROSPECTION_URL"); err != nil {
+		return err
+	}
+	if err := viper.BindEnv("auth.oauth.introspectionClientId", "OAUTH_INTROSPECTION_CLIENT_ID"); err != nil {
+		return err
+	}
+	if err := viper.BindEnv("auth.oauth.introspectionClientSecret", "OAUTH_INTROSPECTION_CLIENT_SECRET"); err != nil {
+		return err
+	}
 
 	// OAuth Admin and Field Mappings
 	if err := viper.BindEnv("auth.oauth.adminUsers", "OAUTH_ADMIN_USERS"); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -220,6 +220,26 @@ monitoring:
 				Expect(cfg.Auth.OAuth.GroupsField).To(Equal("user_groups"))
 				Expect(cfg.Auth.OAuth.AdminGroupName).To(Equal("administrators"))
 			})
+
+			It("should handle OAuth introspection configuration from environment", func() {
+				os.Setenv("OAUTH_ENABLED", "true")
+				os.Setenv("OAUTH_CLIENT_ID", "env-client-id")
+				os.Setenv("OAUTH_CLIENT_SECRET", "env-client-secret")
+				os.Setenv("OAUTH_AUTH_URL", "http://env.example.com/auth")
+				os.Setenv("OAUTH_TOKEN_URL", "http://env.example.com/token")
+				os.Setenv("OAUTH_REDIRECT_URL", "http://localhost:3000/callback")
+				os.Setenv("OAUTH_INTROSPECTION_URL", "http://env.example.com/introspect")
+				os.Setenv("OAUTH_INTROSPECTION_CLIENT_ID", "introspection-client")
+				os.Setenv("OAUTH_INTROSPECTION_CLIENT_SECRET", "introspection-secret")
+
+				err := manager.Load("")
+				Expect(err).NotTo(HaveOccurred())
+
+				cfg := config.GetConfig()
+				Expect(cfg.Auth.OAuth.IntrospectionURL).To(Equal("http://env.example.com/introspect"))
+				Expect(cfg.Auth.OAuth.IntrospectionClientID).To(Equal("introspection-client"))
+				Expect(cfg.Auth.OAuth.IntrospectionClientSecret).To(Equal("introspection-secret"))
+			})
 		})
 
 		Context("with invalid config file", func() {
@@ -708,6 +728,9 @@ auth:
     jwksUrl: "http://auth.example.com/.well-known/jwks.json"
     issuerUrl: "http://auth.example.com"
     logoutUrl: "http://auth.example.com/logout"
+    introspectionUrl: "http://auth.example.com/introspect"
+    introspectionClientId: "introspection-client"
+    introspectionClientSecret: "introspection-secret"
     scopes: 
       - "openid"
       - "profile" 
@@ -740,6 +763,9 @@ auth:
 			Expect(oauth.ClientID).To(Equal("test-client"))
 			Expect(oauth.ClientSecret).To(Equal("test-secret"))
 			Expect(oauth.RedirectURL).To(Equal("http://localhost:8080/callback"))
+			Expect(oauth.IntrospectionURL).To(Equal("http://auth.example.com/introspect"))
+			Expect(oauth.IntrospectionClientID).To(Equal("introspection-client"))
+			Expect(oauth.IntrospectionClientSecret).To(Equal("introspection-secret"))
 			Expect(oauth.AdminUsers).To(ContainElements("admin@example.com", "superuser@example.com"))
 			Expect(oauth.AdminGroups).To(ContainElements("admins", "superusers"))
 			Expect(oauth.AdminGroupName).To(Equal("administrators"))
@@ -836,7 +862,9 @@ func clearTestEnvVars() {
 		"AUTH_ENABLED", "JWT_SECRET", "JWKS_URL", "AUTH_ISSUER", "AUTH_AUDIENCE",
 		"OAUTH_ENABLED", "OAUTH_CLIENT_ID", "OAUTH_CLIENT_SECRET", "OAUTH_REDIRECT_URL",
 		"OAUTH_AUTH_URL", "OAUTH_TOKEN_URL", "OAUTH_USERINFO_URL", "OAUTH_JWKS_URL",
-		"OAUTH_ISSUER_URL", "OAUTH_LOGOUT_URL", "OAUTH_ADMIN_USERS", "OAUTH_ADMIN_GROUPS",
+		"OAUTH_ISSUER_URL", "OAUTH_LOGOUT_URL", "OAUTH_INTROSPECTION_URL",
+		"OAUTH_INTROSPECTION_CLIENT_ID", "OAUTH_INTROSPECTION_CLIENT_SECRET",
+		"OAUTH_ADMIN_USERS", "OAUTH_ADMIN_GROUPS",
 		"OAUTH_USER_ID_FIELD", "OAUTH_EMAIL_FIELD", "OAUTH_NAME_FIELD", "OAUTH_GROUPS_FIELD", "OAUTH_ROLES_FIELD",
 		"OAUTH_ADMIN_GROUP_NAME", "OAUTH_MANAGER_GROUP_NAME", "OAUTH_USER_GROUP_NAME",
 		"REDIS_HOST", "REDIS_PORT", "REDIS_PASSWORD",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bind missing OAuth introspection settings to Viper so env vars are picked up at startup. This lets us configure the introspection URL and client credentials via OAUTH_* variables.

- **Bug Fixes**
  - Bind auth.oauth.introspectionUrl to OAUTH_INTROSPECTION_URL
  - Bind auth.oauth.introspectionClientId to OAUTH_INTROSPECTION_CLIENT_ID
  - Bind auth.oauth.introspectionClientSecret to OAUTH_INTROSPECTION_CLIENT_SECRET

<sup>Written for commit 91ecf31d8072e3cccdd2dd59d18e85819e2f5137. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



