### PR TITLE
feat: support Fern without authentication

### DIFF
--- a/internal/domains/auth/interfaces/middleware_adapter.go
+++ b/internal/domains/auth/interfaces/middleware_adapter.go
@@ -64,7 +64,14 @@ func NewAuthMiddlewareAdapter(
 // RequireAuth middleware validates OAuth sessions and ensures user is authenticated
 func (m *AuthMiddlewareAdapter) RequireAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if !m.config.Enabled || !m.config.OAuth.Enabled {
+		if !m.config.Enabled {
+			// Auth disabled - create dummy admin user
+			m.setDummyAdminUser(c)
+			c.Next()
+			return
+		}
+		
+		if !m.config.OAuth.Enabled {
 			c.Next()
 			return
 		}
@@ -232,6 +239,13 @@ func (m *AuthMiddlewareAdapter) RequireAuth() gin.HandlerFunc {
 // RequireAdmin middleware ensures user has admin role
 func (m *AuthMiddlewareAdapter) RequireAdmin() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !m.config.Enabled {
+			// Auth disabled - create dummy admin user
+			m.setDummyAdminUser(c)
+			c.Next()
+			return
+		}
+		
 		// First ensure user is authenticated
 		m.RequireAuth()(c)
 		if c.IsAborted() {
@@ -267,6 +281,13 @@ func (m *AuthMiddlewareAdapter) RequireAdmin() gin.HandlerFunc {
 // RequireManager middleware ensures user has manager privileges
 func (m *AuthMiddlewareAdapter) RequireManager() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !m.config.Enabled {
+			// Auth disabled - create dummy admin user
+			m.setDummyAdminUser(c)
+			c.Next()
+			return
+		}
+		
 		// First ensure user is authenticated
 		m.RequireAuth()(c)
 		if c.IsAborted() {
@@ -310,6 +331,11 @@ func GenerateCodeChallenge(verifier string) string {
 // StartOAuthFlow initiates the OAuth authentication flow
 func (m *AuthMiddlewareAdapter) StartOAuthFlow() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !m.config.Enabled {
+			c.JSON(400, gin.H{"error": "Authentication is disabled"})
+			return
+		}
+		
 		if !m.config.OAuth.Enabled {
 			c.JSON(400, gin.H{"error": "OAuth not enabled"})
 			return
@@ -357,6 +383,11 @@ func (m *AuthMiddlewareAdapter) StartOAuthFlow() gin.HandlerFunc {
 // HandleOAuthCallback handles the OAuth callback
 func (m *AuthMiddlewareAdapter) HandleOAuthCallback() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !m.config.Enabled {
+			c.JSON(400, gin.H{"error": "Authentication is disabled"})
+			return
+		}
+		
 		if !m.config.OAuth.Enabled {
 			c.JSON(400, gin.H{"error": "OAuth not enabled"})
 			return
@@ -442,6 +473,11 @@ func (m *AuthMiddlewareAdapter) HandleOAuthCallback() gin.HandlerFunc {
 // Logout handles user logout
 func (m *AuthMiddlewareAdapter) Logout() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !m.config.Enabled {
+			c.JSON(200, gin.H{"message": "Authentication is disabled"})
+			return
+		}
+		
 		sessionID, err := c.Cookie("session_id")
 		if err == nil && sessionID != "" {
 			// Get session for ID token
@@ -588,4 +624,30 @@ func CanAccessTeamProjects(c *gin.Context, team string) bool {
 	}
 
 	return false
+}
+
+// setDummyAdminUser creates and sets an in-memory admin user when auth is disabled
+func (m *AuthMiddlewareAdapter) setDummyAdminUser(c *gin.Context) {
+	dummyAdmin := &domain.User{
+		UserID:        "admin",
+		Email:         "admin@fern-platform.local",
+		Name:          "Admin User",
+		FirstName:     "Admin",
+		LastName:      "User",
+		Role:          domain.RoleAdmin,
+		Status:        domain.StatusActive,
+		EmailVerified: true,
+		Groups: []domain.UserGroup{
+			{
+				UserID:    "admin",
+				GroupName: "fern-admins",
+			},
+		},
+	}
+
+	// Set the dummy admin user in context
+	c.Set("user", dummyAdmin)
+	c.Set("user_id", dummyAdmin.UserID)
+	c.Set("user_role", string(dummyAdmin.Role))
+	c.Set("auth_disabled", true)
 }

--- a/internal/domains/auth/interfaces/middleware_adapter_test.go
+++ b/internal/domains/auth/interfaces/middleware_adapter_test.go
@@ -478,6 +478,67 @@ var _ = Describe("AuthMiddlewareAdapter", Label("auth"), func() {
 		})
 	})
 
+	Describe("Auth Disabled", func() {
+		BeforeEach(func() {
+			cfg.Enabled = false
+		})
+
+		It("sets dummy admin user when auth is disabled in RequireAuth", func() {
+			mw := adapter.RequireAuth()
+			mw(c)
+
+			Expect(c.IsAborted()).To(BeFalse())
+			user, exists := c.Get("user")
+			Expect(exists).To(BeTrue())
+			Expect(user.(*domain.User).UserID).To(Equal("admin"))
+			Expect(user.(*domain.User).Role).To(Equal(domain.RoleAdmin))
+			Expect(user.(*domain.User).Email).To(Equal("admin@fern-platform.local"))
+			authDisabled, _ := c.Get("auth_disabled")
+			Expect(authDisabled).To(BeTrue())
+		})
+
+		It("sets dummy admin user when auth is disabled in RequireAdmin", func() {
+			mw := adapter.RequireAdmin()
+			mw(c)
+
+			Expect(c.IsAborted()).To(BeFalse())
+			user, exists := c.Get("user")
+			Expect(exists).To(BeTrue())
+			Expect(user.(*domain.User).IsAdmin()).To(BeTrue())
+		})
+
+		It("sets dummy admin user when auth is disabled in RequireManager", func() {
+			mw := adapter.RequireManager()
+			mw(c)
+
+			Expect(c.IsAborted()).To(BeFalse())
+			user, exists := c.Get("user")
+			Expect(exists).To(BeTrue())
+			Expect(user.(*domain.User).IsAdmin()).To(BeTrue())
+		})
+
+		It("returns error on StartOAuthFlow when auth is disabled", func() {
+			mw := adapter.StartOAuthFlow()
+			mw(c)
+			Expect(recorder.Code).To(Equal(400))
+			Expect(recorder.Body.String()).To(ContainSubstring("Authentication is disabled"))
+		})
+
+		It("returns error on HandleOAuthCallback when auth is disabled", func() {
+			mw := adapter.HandleOAuthCallback()
+			mw(c)
+			Expect(recorder.Code).To(Equal(400))
+			Expect(recorder.Body.String()).To(ContainSubstring("Authentication is disabled"))
+		})
+
+		It("returns message on Logout when auth is disabled", func() {
+			mw := adapter.Logout()
+			mw(c)
+			Expect(recorder.Code).To(Equal(200))
+			Expect(recorder.Body.String()).To(ContainSubstring("Authentication is disabled"))
+		})
+	})
+
 	// -----------------Nimish -----------------
 
 	Describe("CanAccessTeamProjects", func() {

--- a/internal/reporter/graphql/generated/generated.go
+++ b/internal/reporter/graphql/generated/generated.go
@@ -52,6 +52,11 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	AuthConfiguration struct {
+		Enabled      func(childComplexity int) int
+		OauthEnabled func(childComplexity int) int
+	}
+
 	DashboardSummary struct {
 		ActiveProjectCount  func(childComplexity int) int
 		AverageTestDuration func(childComplexity int) int
@@ -302,6 +307,7 @@ type ComplexityRoot struct {
 	}
 
 	SystemConfig struct {
+		AuthConfig func(childComplexity int) int
 		RoleGroups func(childComplexity int) int
 	}
 
@@ -495,6 +501,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	ec := executionContext{nil, e, 0, 0, nil}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "AuthConfiguration.enabled":
+		if e.complexity.AuthConfiguration.Enabled == nil {
+			break
+		}
+
+		return e.complexity.AuthConfiguration.Enabled(childComplexity), true
+
+	case "AuthConfiguration.oauthEnabled":
+		if e.complexity.AuthConfiguration.OauthEnabled == nil {
+			break
+		}
+
+		return e.complexity.AuthConfiguration.OauthEnabled(childComplexity), true
 
 	case "DashboardSummary.activeProjectCount":
 		if e.complexity.DashboardSummary.ActiveProjectCount == nil {
@@ -1976,6 +1996,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SuiteTreemapNode.TotalSpecs(childComplexity), true
 
+	case "SystemConfig.authConfig":
+		if e.complexity.SystemConfig.AuthConfig == nil {
+			break
+		}
+
+		return e.complexity.SystemConfig.AuthConfig(childComplexity), true
+
 	case "SystemConfig.roleGroups":
 		if e.complexity.SystemConfig.RoleGroups == nil {
 			break
@@ -2929,12 +2956,18 @@ type UserPreferences {
 # System Configuration Type
 type SystemConfig {
   roleGroups: RoleGroupConfig!
+  authConfig: AuthConfiguration!
 }
 
 type RoleGroupConfig {
   adminGroup: String!
   managerGroup: String!
   userGroup: String!
+}
+
+type AuthConfiguration {
+  enabled: Boolean!
+  oauthEnabled: Boolean!
 }
 
 # JIRA Integration Types
@@ -3818,6 +3851,94 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _AuthConfiguration_enabled(ctx context.Context, field graphql.CollectedField, obj *model.AuthConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuthConfiguration_enabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Enabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuthConfiguration_enabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuthConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuthConfiguration_oauthEnabled(ctx context.Context, field graphql.CollectedField, obj *model.AuthConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuthConfiguration_oauthEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OauthEnabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuthConfiguration_oauthEnabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuthConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _DashboardSummary_health(ctx context.Context, field graphql.CollectedField, obj *model.DashboardSummary) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DashboardSummary_health(ctx, field)
@@ -9398,6 +9519,8 @@ func (ec *executionContext) fieldContext_Query_systemConfig(_ context.Context, f
 			switch field.Name {
 			case "roleGroups":
 				return ec.fieldContext_SystemConfig_roleGroups(ctx, field)
+			case "authConfig":
+				return ec.fieldContext_SystemConfig_authConfig(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SystemConfig", field.Name)
 		},
@@ -13802,6 +13925,56 @@ func (ec *executionContext) fieldContext_SystemConfig_roleGroups(_ context.Conte
 				return ec.fieldContext_RoleGroupConfig_userGroup(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RoleGroupConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SystemConfig_authConfig(ctx context.Context, field graphql.CollectedField, obj *model.SystemConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SystemConfig_authConfig(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AuthConfig, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.AuthConfiguration)
+	fc.Result = res
+	return ec.marshalNAuthConfiguration2ᚖgithubᚗcomᚋguidewireᚑossᚋfernᚑplatformᚋinternalᚋreporterᚋgraphqlᚋmodelᚐAuthConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SystemConfig_authConfig(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SystemConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "enabled":
+				return ec.fieldContext_AuthConfiguration_enabled(ctx, field)
+			case "oauthEnabled":
+				return ec.fieldContext_AuthConfiguration_oauthEnabled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AuthConfiguration", field.Name)
 		},
 	}
 	return fc, nil
@@ -19671,6 +19844,50 @@ func (ec *executionContext) unmarshalInputUpdateUserPreferencesInput(ctx context
 
 // region    **************************** object.gotpl ****************************
 
+var authConfigurationImplementors = []string{"AuthConfiguration"}
+
+func (ec *executionContext) _AuthConfiguration(ctx context.Context, sel ast.SelectionSet, obj *model.AuthConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, authConfigurationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AuthConfiguration")
+		case "enabled":
+			out.Values[i] = ec._AuthConfiguration_enabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "oauthEnabled":
+			out.Values[i] = ec._AuthConfiguration_oauthEnabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var dashboardSummaryImplementors = []string{"DashboardSummary"}
 
 func (ec *executionContext) _DashboardSummary(ctx context.Context, sel ast.SelectionSet, obj *model.DashboardSummary) graphql.Marshaler {
@@ -21844,6 +22061,11 @@ func (ec *executionContext) _SystemConfig(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "authConfig":
+			out.Values[i] = ec._SystemConfig_authConfig(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -22901,6 +23123,16 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
+
+func (ec *executionContext) marshalNAuthConfiguration2ᚖgithubᚗcomᚋguidewireᚑossᚋfernᚑplatformᚋinternalᚋreporterᚋgraphqlᚋmodelᚐAuthConfiguration(ctx context.Context, sel ast.SelectionSet, v *model.AuthConfiguration) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AuthConfiguration(ctx, sel, v)
+}
 
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)

--- a/internal/reporter/graphql/model/models_gen.go
+++ b/internal/reporter/graphql/model/models_gen.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+type AuthConfiguration struct {
+	Enabled      bool `json:"enabled"`
+	OauthEnabled bool `json:"oauthEnabled"`
+}
+
 type CreateJiraConnectionInput struct {
 	ProjectID          string `json:"projectId"`
 	Name               string `json:"name"`
@@ -259,7 +264,8 @@ type SuiteTreemapNode struct {
 }
 
 type SystemConfig struct {
-	RoleGroups *RoleGroupConfig `json:"roleGroups"`
+	RoleGroups *RoleGroupConfig   `json:"roleGroups"`
+	AuthConfig *AuthConfiguration `json:"authConfig"`
 }
 
 type Tag struct {

--- a/internal/reporter/graphql/schema.graphql
+++ b/internal/reporter/graphql/schema.graphql
@@ -312,12 +312,18 @@ type UserPreferences {
 # System Configuration Type
 type SystemConfig {
   roleGroups: RoleGroupConfig!
+  authConfig: AuthConfiguration!
 }
 
 type RoleGroupConfig {
   adminGroup: String!
   managerGroup: String!
   userGroup: String!
+}
+
+type AuthConfiguration {
+  enabled: Boolean!
+  oauthEnabled: Boolean!
 }
 
 # JIRA Integration Types

--- a/internal/reporter/graphql/schema.resolvers.go
+++ b/internal/reporter/graphql/schema.resolvers.go
@@ -16,6 +16,7 @@ import (
 	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
 	"github.com/guidewire-oss/fern-platform/internal/reporter/graphql/generated"
 	"github.com/guidewire-oss/fern-platform/internal/reporter/graphql/model"
+	"github.com/guidewire-oss/fern-platform/pkg/config"
 	"github.com/guidewire-oss/fern-platform/pkg/database"
 	"gorm.io/gorm"
 )
@@ -629,11 +630,18 @@ func (r *queryResolver) SystemConfig(ctx context.Context) (*model.SystemConfig, 
 	// Get role group names from context
 	roleGroups := getRoleGroupNamesFromContext(ctx)
 
+	// Get auth configuration from config package
+	authConfig := config.GetAuthConfig()
+
 	return &model.SystemConfig{
 		RoleGroups: &model.RoleGroupConfig{
 			AdminGroup:   roleGroups.AdminGroup,
 			ManagerGroup: roleGroups.ManagerGroup,
 			UserGroup:    roleGroups.UserGroup,
+		},
+		AuthConfig: &model.AuthConfiguration{
+			Enabled:      authConfig.Enabled,
+			OauthEnabled: authConfig.OAuth.Enabled,
 		},
 	}, nil
 }

--- a/web/index.html
+++ b/web/index.html
@@ -2237,9 +2237,47 @@
             
             const checkAuth = async () => {
                 try {
-                    // Fetch both user and system config
-                    const query = `
-                        query GetAuthData {
+                    // Always fetch system config first - this should work even without auth
+                    const configQuery = `
+                        query GetSystemConfig {
+                            systemConfig {
+                                roleGroups {
+                                    adminGroup
+                                    managerGroup
+                                    userGroup
+                                }
+                                authConfig {
+                                    enabled
+                                    oauthEnabled
+                                }
+                            }
+                        }
+                    `;
+                    
+                    const configData = await graphqlClient.query({ query: configQuery });
+                    if (configData && configData.systemConfig) {
+                        setSystemConfig(configData.systemConfig);
+                    }
+                } catch (error) {
+                    console.log('Failed to fetch system config:', error);
+                    // Set default system config if fetch fails
+                    setSystemConfig({
+                        roleGroups: {
+                            adminGroup: 'admin',
+                            managerGroup: 'manager',
+                            userGroup: 'user'
+                        },
+                        authConfig: {
+                            enabled: false,  // Default to disabled for safety
+                            oauthEnabled: false
+                        }
+                    });
+                }
+                
+                // Then try to fetch current user (only works if auth is enabled)
+                try {
+                    const userQuery = `
+                        query GetCurrentUser {
                             currentUser {
                                 id
                                 userId
@@ -2253,22 +2291,12 @@
                                 createdAt
                                 lastLoginAt
                             }
-                            systemConfig {
-                                roleGroups {
-                                    adminGroup
-                                    managerGroup
-                                    userGroup
-                                }
-                            }
                         }
                     `;
                     
-                    const data = await graphqlClient.query({ query });
-                    if (data && data.currentUser) {
-                        setUser(data.currentUser);
-                    }
-                    if (data && data.systemConfig) {
-                        setSystemConfig(data.systemConfig);
+                    const userData = await graphqlClient.query({ query: userQuery });
+                    if (userData && userData.currentUser) {
+                        setUser(userData.currentUser);
                     }
                 } catch (error) {
                     console.log('Not authenticated:', error);
@@ -2333,6 +2361,10 @@
                        group !== roleGroups.userGroup;
             }) || [];
             
+            // Get auth configuration
+            const authConfig = systemConfig?.authConfig || { enabled: false, oauthEnabled: false };
+            const isAuthEnabled = authConfig.enabled;
+            
             return { 
                 user, 
                 systemConfig,
@@ -2341,7 +2373,8 @@
                 logout, 
                 isAdmin,
                 isManager,
-                userTeams
+                userTeams,
+                isAuthEnabled
             };
         }
 
@@ -2578,7 +2611,7 @@
         // Modern Header component
         function Header({ health, projects, testRuns, onOpenSettings }) {
             const { theme, toggleTheme } = useUserPreferences();
-            const { user, loading, login, logout } = useAuth();
+            const { user, loading, login, logout, isAuthEnabled } = useAuth();
             const activeProjects = projects.filter(p => p.isActive).length;
             const recentRuns = testRuns.filter(tr => {
                 const runDate = new Date(tr.startTime);
@@ -2649,7 +2682,10 @@
                             </button>
 
                             {/* Authentication UI */}
-                            {loading ? (
+                            {!isAuthEnabled ? (
+                                // Auth is disabled - show nothing or a simple indicator
+                                null
+                            ) : loading ? (
                                 <div style={{
                                     display: 'flex',
                                     alignItems: 'center',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable running Fern without authentication. When auth is disabled, requests proceed with a dummy admin user, and the UI adapts by hiding login controls and still loading system config.

- **New Features**
  - Auth middleware: if config.Enabled is false, set a dummy admin user in context and allow RequireAuth/Admin/Manager to pass; OAuth endpoints return clear errors or messages.
  - GraphQL: added SystemConfig.authConfig with enabled and oauthEnabled; resolver reads from application config.
  - Web: fetch systemConfig first (works without auth), then try currentUser; hide auth UI when auth is disabled; sensible defaults if config fetch fails.
  - Tests: coverage for disabled-auth paths in RequireAuth/Admin/Manager, OAuth flow handlers, and Logout.

<sup>Written for commit d94ad6f8004ceb0c49db3a5c16b91aea3d017067. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

