### PR TITLE
docs(readme): Replace ASCII diagram with Mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,23 +203,27 @@ See [integration guide](docs/developers/integration-guide.md) for more examples.
 
 Fern Platform uses domain-driven design with a hexagonal architecture:
 
-```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   Web UI        │     │   REST API      │     │   GraphQL API   │
-└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
-         └──────────────────────┬┴──────────────────────────┘
-                                │
-                    ┌───────────┴────────────┐
-                    │   Business Domains     │
-                    │  ┌─────┐ ┌─────────┐  │
-                    │  │Tests│ │Analytics│  │
-                    │  └─────┘ └─────────┘  │
-                    └───────────┬────────────┘
-                                │
-                    ┌───────────┴────────────┐
-                    │   Infrastructure       │
-                    │  PostgreSQL + Redis    │
-                    └────────────────────────┘
+```mermaid
+graph TD
+    subgraph Clients [" "]
+        direction LR
+        UI["Web UI"]
+        REST["REST API"]
+        GQL["GraphQL API"]
+    end
+
+    subgraph Domains ["Business Domains"]
+        direction LR
+        Tests["Tests"]
+        Analytics["Analytics"]
+    end
+
+    subgraph Storage ["Infrastructure"]
+        DB["PostgreSQL + Redis"]
+    end
+
+    UI & REST & GQL --> Domains
+    Domains --> Storage
 ```
 
 ## The Vision: Where We're Heading

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ graph TD
         DB["PostgreSQL + Redis"]
     end
 
-    UI & REST & GQL --> Domains
-    Domains --> Storage
+    UI & REST & GQL --- Domains
+    Domains --- Storage
 ```
 
 ## The Vision: Where We're Heading


### PR DESCRIPTION
- Replace ASCII diagram with [Mermaid diagram](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the README’s ASCII architecture diagram with a GitHub-native Mermaid diagram for clearer structure and native rendering. Uses a top-down flow with subgraphs for Clients (Web UI, REST, GraphQL), Business Domains (Tests, Analytics), and Infrastructure (PostgreSQL + Redis); fixed connections so all clients link to Domains and Domains to Storage.

<sup>Written for commit cd07b10e53c3fd67c48431319710e24d5bf563f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

