### PR TITLE
chore: upgrade postgres to 17.5

### DIFF
--- a/deployments/components/cnpg.cue
+++ b/deployments/components/cnpg.cue
@@ -26,8 +26,12 @@ template: {
 				description: parameter.description
 			}
 
+			if parameter.imageName != "" {
+				imageName: parameter.imageName
+			}
+
 			if parameter.imageName == "" {
-				imageName: "ghcr.io/cloudnative-pg/postgresql:13.13-13"
+				imageName: "ghcr.io/cloudnative-pg/postgresql:17.5"
 			}
 
 			if parameter.instances > 0 {

--- a/deployments/fern-platform-kubevela.yaml
+++ b/deployments/fern-platform-kubevela.yaml
@@ -14,6 +14,7 @@ spec:
         namespace: fern-platform
         instances: 1
         storageSize: 0.5Gi
+        imageName: "ghcr.io/cloudnative-pg/postgresql:17.5"
 
     # Redis Cache
     - name: redis


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade PostgreSQL to ghcr.io/cloudnative-pg/postgresql:17.5 across CNPG. CNPG defaults to 17.5 and supports an imageName override; fern-platform pins 17.5; expect pod restarts on rollout.

<sup>Written for commit 028c4ce812e87ec86a55fc340fd6562a75866f61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

