### PR TITLE
fix: require token for POST calls and paginate testruns

### DIFF
--- a/internal/api/domain_handler.go
+++ b/internal/api/domain_handler.go
@@ -71,24 +71,27 @@ func (h *DomainHandler) RegisterRoutes(router *gin.Engine) {
 	// API v1 routes
 	apiV1 := router.Group("/api/v1")
 	{
-		// Public routes for test result submission
-		// These are compatible with the legacy Fern Reporter API
-		apiV1.POST("/test-runs", h.recordTestRun)
-		apiV1.POST("/test-runs/start", h.startTestRun)
-		apiV1.POST("/test-runs/complete", h.completeTestRun)
-		apiV1.POST("/suite-runs", h.addSuiteRun)
-		apiV1.POST("/spec-runs", h.addSpecRun)
-		apiV1.PUT("/test-runs/:id", h.updateTestRun)
-
 		// Protected routes - require authentication
 		protected := apiV1.Group("/")
 		protected.Use(h.authMiddleware.RequireAuth())
 		{
-			// Test runs
+			// Test runs - read operations
 			protected.GET("/test-runs", h.getTestRuns)
 			protected.GET("/test-runs/:id", h.getTestRun)
 			protected.GET("/test-runs/by-run-id/:id", h.getTestRunByRunId)
 			protected.DELETE("/test-runs/:id", h.deleteTestRun)
+
+			// Test runs - write operations (result submission)
+			protected.POST("/test-runs", h.recordTestRun)
+			protected.POST("/test-runs/start", h.startTestRun)
+			protected.POST("/test-runs/complete", h.completeTestRun)
+			protected.PUT("/test-runs/:id", h.updateTestRun)
+
+			// Suite runs
+			protected.POST("/suite-runs", h.addSuiteRun)
+
+			// Spec runs
+			protected.POST("/spec-runs", h.addSpecRun)
 
 			// Suites
 			protected.GET("/test-runs/:id/suite-runs", h.getSuiteRuns)

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -112,6 +112,19 @@ func (m *MockTestRunRepository) CountByProjectID(ctx context.Context, projectID 
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockTestRunRepository) Count(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) List(ctx context.Context, limit, offset int) ([]*domain.TestRun, int64, error) {
+	args := m.Called(ctx, limit, offset)
+	if args.Get(0) == nil {
+		return nil, 0, args.Error(2)
+	}
+	return args.Get(0).([]*domain.TestRun), args.Get(1).(int64), args.Error(2)
+}
+
 // MockSuiteRunRepository provides a mock implementation of SuiteRunRepository
 type MockSuiteRunRepository struct {
 	mock.Mock
@@ -486,8 +499,9 @@ var _ = Describe("TestRunHandler", func() {
 		})
 
 		It("should handle list test runs without project ID", func() {
-			// When no project ID is provided, the service returns empty list
-			// This matches the current implementation in test_run_service.go
+			// When no project ID is provided, the service calls List with default pagination
+			testRunRepo.On("List", mock.Anything, 50, 0).Return([]*domain.TestRun{}, int64(0), nil).Once()
+
 			req := httptest.NewRequest("GET", "/api/v1/test-runs", nil)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
@@ -533,8 +547,9 @@ var _ = Describe("TestRunHandler", func() {
 		})
 
 		It("should count test runs without project ID", func() {
-			// When no project ID is provided, the service returns 0
-			// This matches the current implementation in test_run_service.go
+			// When no project ID is provided, the service calls List with limit=0
+			testRunRepo.On("List", mock.Anything, 0, 0).Return([]*domain.TestRun{}, int64(0), nil).Once()
+
 			req := httptest.NewRequest("GET", "/api/v1/test-runs/count", nil)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)

--- a/internal/domains/testing/application/complete_test_run_test.go
+++ b/internal/domains/testing/application/complete_test_run_test.go
@@ -42,6 +42,10 @@ func (m *mockTestRunRepo) Update(ctx context.Context, tr *domain.TestRun) error 
 	args := m.Called(ctx, tr)
 	return args.Error(0)
 }
+func (m *mockTestRunRepo) Count(ctx context.Context) (int64, error) { return 0, nil }
+func (m *mockTestRunRepo) List(ctx context.Context, limit, offset int) ([]*domain.TestRun, int64, error) {
+	return nil, 0, nil
+}
 
 type mockFlakyRepo struct{ mock.Mock }
 

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -321,14 +321,11 @@ func (s *TestRunService) DeleteTestRun(ctx context.Context, id uint) error {
 
 // ListTestRuns retrieves test runs with pagination and filtering
 func (s *TestRunService) ListTestRuns(ctx context.Context, projectID string, limit, offset int) ([]*domain.TestRun, int64, error) {
-	// For now, use GetLatestByProjectID with limit
-	// TODO: Add proper filtering support to repository
 	if projectID != "" {
 		runs, err := s.testRunRepo.GetLatestByProjectID(ctx, projectID, limit)
 		if err != nil {
 			return nil, 0, err
 		}
-		// Get total count
 		total, err := s.testRunRepo.CountByProjectID(ctx, projectID)
 		if err != nil {
 			return nil, 0, err
@@ -336,9 +333,12 @@ func (s *TestRunService) ListTestRuns(ctx context.Context, projectID string, lim
 		return runs, total, nil
 	}
 
-	// If no project ID, return empty for now
-	// TODO: Add GetAll method to repository
-	return []*domain.TestRun{}, 0, nil
+	return s.testRunRepo.List(ctx, limit, offset)
+}
+
+// CountTestRuns counts all test runs
+func (s *TestRunService) CountTestRuns(ctx context.Context) (int64, error) {
+	return s.testRunRepo.Count(ctx)
 }
 
 // GetSuiteRunsByTestRunID retrieves all suite runs for a test run

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -147,6 +147,19 @@ func (m *MockTestRunRepository) GetTestRunSummary(ctx context.Context, projectID
 	return args.Get(0).(*domain.TestRunSummary), args.Error(1)
 }
 
+func (m *MockTestRunRepository) Count(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) List(ctx context.Context, limit, offset int) ([]*domain.TestRun, int64, error) {
+	args := m.Called(ctx, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*domain.TestRun), args.Get(1).(int64), args.Error(2)
+}
+
 // Mock suite run repository
 type MockSuiteRunRepository struct {
 	mock.Mock
@@ -779,6 +792,8 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 		})
 
 		It("should return empty list when no project ID", func() {
+			mockTestRunRepo.On("List", mock.Anything, 10, 0).Return([]*domain.TestRun{}, int64(0), nil)
+
 			results, count, err := service.ListTestRuns(ctx, "", 10, 0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(results).To(BeEmpty())

--- a/internal/domains/testing/domain/repository.go
+++ b/internal/domains/testing/domain/repository.go
@@ -33,8 +33,14 @@ type TestRunRepository interface {
 	// CountByProjectID counts test runs for a project
 	CountByProjectID(ctx context.Context, projectID string) (int64, error)
 
+	// Count counts all test runs
+	Count(ctx context.Context) (int64, error)
+
 	// GetRecent retrieves recent test runs across all projects
 	GetRecent(ctx context.Context, limit int) ([]*TestRun, error)
+
+	// List retrieves test runs with pagination
+	List(ctx context.Context, limit, offset int) ([]*TestRun, int64, error)
 }
 
 // SuiteRunRepository defines the interface for suite run persistence

--- a/internal/domains/testing/infrastructure/gorm_test_run_repo.go
+++ b/internal/domains/testing/infrastructure/gorm_test_run_repo.go
@@ -244,6 +244,13 @@ func (r *GormTestRunRepository) CountByProjectID(ctx context.Context, projectID 
 	return count, err
 }
 
+// Count counts all test runs
+func (r *GormTestRunRepository) Count(ctx context.Context) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Model(&database.TestRun{}).Count(&count).Error
+	return count, err
+}
+
 // GetRecent retrieves recent test runs across all projects
 func (r *GormTestRunRepository) GetRecent(ctx context.Context, limit int) ([]*domain.TestRun, error) {
 	var dbTestRuns []database.TestRun
@@ -270,6 +277,33 @@ func (r *GormTestRunRepository) GetRecent(ctx context.Context, limit int) ([]*do
 	}
 
 	return testRuns, nil
+}
+
+// List retrieves test runs with pagination across all projects
+func (r *GormTestRunRepository) List(ctx context.Context, limit, offset int) ([]*domain.TestRun, int64, error) {
+	var dbTestRuns []database.TestRun
+	var total int64
+
+	if err := r.db.WithContext(ctx).Model(&database.TestRun{}).Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count test runs: %w", err)
+	}
+
+	query := r.db.WithContext(ctx).
+		Model(&database.TestRun{}).
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset)
+
+	if err := query.Find(&dbTestRuns).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to list test runs: %w", err)
+	}
+
+	testRuns := make([]*domain.TestRun, len(dbTestRuns))
+	for i, dbTestRun := range dbTestRuns {
+		testRuns[i] = r.converter.ConvertTestRunToDomain(&dbTestRun)
+	}
+
+	return testRuns, total, nil
 }
 
 // GetDB returns the underlying GORM DB instance.

--- a/internal/reporter/graphql/domain_resolvers.go
+++ b/internal/reporter/graphql/domain_resolvers.go
@@ -1130,9 +1130,9 @@ func (r *queryResolver) TreemapData_domain(ctx context.Context, projectID *strin
 
 // TestRuns implementation using domain service with pagination
 func (r *queryResolver) TestRuns_domain(ctx context.Context, filter *model.TestRunFilter, first *int, after *string, orderBy *string, orderDirection *model.OrderDirection) (*model.TestRunConnection, error) {
-	// Apply pagination
-	pageSize := 20
-	if first != nil && *first > 0 && *first <= 100 {
+	// Apply pagination - default 50 per page
+	pageSize := 50
+	if first != nil && *first > 0 && *first <= 200 {
 		pageSize = *first
 	}
 

--- a/internal/reporter/graphql/domain_resolvers_ginkgo_test.go
+++ b/internal/reporter/graphql/domain_resolvers_ginkgo_test.go
@@ -884,7 +884,7 @@ var _ = Describe("DomainResolvers", func() {
 
 		Context("without project filter", func() {
 			It("should return empty results when no test runs exist", func() {
-				mockRepo.On("FindAll", mock.Anything, 20, 0).Return([]*testingDomain.TestRun{}, int64(0), nil)
+				mockRepo.On("List", mock.Anything, 50, 0).Return([]*testingDomain.TestRun{}, int64(0), nil)
 
 				result, err := resolver.Query().(*queryResolver).TestRuns_domain(ctx, nil, nil, nil, nil, nil)
 

--- a/internal/reporter/graphql/schema_resolvers_test.go
+++ b/internal/reporter/graphql/schema_resolvers_test.go
@@ -36,6 +36,9 @@ func setupTestProjectResolver(t *testing.T) *projectResolver {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 
+	err = db.AutoMigrate(&database.ProjectPermission{})
+	require.NoError(t, err)
+
 	resolver := &Resolver{
 		logger: logger,
 		db:     db,
@@ -310,7 +313,7 @@ var _ = Describe("Schema Resolvers - Ginkgo Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Migrate tables
-		err = db.AutoMigrate(&database.UserPreferences{}, &database.TestRun{}, &database.SuiteRun{}, &database.SpecRun{}, &database.Tag{})
+		err = db.AutoMigrate(&database.UserPreferences{}, &database.TestRun{}, &database.SuiteRun{}, &database.SpecRun{}, &database.Tag{}, &database.ProjectPermission{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create a minimal resolver without services

--- a/internal/testhelpers/mocks.go
+++ b/internal/testhelpers/mocks.go
@@ -284,6 +284,19 @@ func (m *MockTestRunRepository) Create(ctx context.Context, testRun *testingDoma
 	return args.Error(0)
 }
 
+func (m *MockTestRunRepository) Count(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) List(ctx context.Context, limit, offset int) ([]*testingDomain.TestRun, int64, error) {
+	args := m.Called(ctx, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*testingDomain.TestRun), args.Get(1).(int64), args.Error(2)
+}
+
 // MockTagRepository is a mock implementation of tagsDomain.TagRepository
 type MockTagRepository struct {
 	mock.Mock

--- a/web/index.html
+++ b/web/index.html
@@ -2208,8 +2208,18 @@
 
         // Simple router for SPA navigation
         function useRouter() {
-            const [route, setRoute] = useState(window.location.hash.slice(1) || '/');
-            
+            const [route, setRoute] = useState(() => {
+                const hash = window.location.hash.slice(1);
+                if (!hash) {
+                    // Replace the current history entry with a hash-based URL so that
+                    // all navigation entries are consistent hash fragments. This ensures
+                    // the browser back button navigates between hash routes rather than
+                    // returning to a no-hash URL (which can reload the page in some browsers).
+                    history.replaceState(null, '', '#/');
+                }
+                return hash || '/';
+            });
+
             useEffect(() => {
                 const handleHashChange = () => {
                     setRoute(window.location.hash.slice(1) || '/');
@@ -2217,11 +2227,11 @@
                 window.addEventListener('hashchange', handleHashChange);
                 return () => window.removeEventListener('hashchange', handleHashChange);
             }, []);
-            
+
             const navigate = (path) => {
                 window.location.hash = path;
             };
-            
+
             return { route, navigate };
         }
 
@@ -4382,18 +4392,18 @@
             const fetchData = async () => {
                 try {
                     // Fetch critical data in parallel (projects and test runs)
-                    // TestHistoryChart needs test runs, but only summary data (not full nested details)
                     const [projectsData, testRunsData] = await Promise.all([
                         graphqlClient.query(GRAPHQL_QUERIES.GET_PROJECTS_LIST, { first: 100 }),
-                        graphqlClient.query(GRAPHQL_QUERIES.GET_RECENT_TEST_RUNS_SUMMARY, { limit: 100 })
+                        graphqlClient.query(GRAPHQL_QUERIES.GET_TEST_RUNS_PAGINATED, { first: 100 })
                     ]);
-                    
+
                     // Convert projects from edges format
                     const projectList = projectsData.projects.edges.map(edge => edge.node);
                     setProjects(projectList);
-                    
+
                     // Set test runs with project names - needed for TestHistoryChart
-                    const testRunsWithProjects = (testRunsData.recentTestRuns || []).map(run => {
+                    const testRunsWithProjects = (testRunsData.testRuns?.edges || []).map(edge => {
+                        const run = edge.node;
                         const project = projectList.find(p => p.projectId === run.projectId);
                         return {
                             ...run,
@@ -4401,7 +4411,7 @@
                         };
                     });
                     setTestRuns(testRunsWithProjects);
-                    
+
                     // Fetch treemap data separately so it doesn't block rendering
                     // If treemap fails, projects and test runs can still render
                     try {
@@ -4411,7 +4421,7 @@
                         console.warn('Failed to load treemap data:', treemapErr);
                         // Continue without treemap - component will handle missing data
                     }
-                    
+
                     setLoading(false);
                 } catch (err) {
                     console.error('Error fetching test summaries data:', err);
@@ -4715,30 +4725,33 @@
             const [loading, setLoading] = useState(true);
             const [error, setError] = useState(null);
             const [view, setView] = useState('runs'); // 'runs', 'suites', 'specs'
+            const [pageInfo, setPageInfo] = useState(null);
+            const [totalCount, setTotalCount] = useState(0);
+            const [currentCursor, setCurrentCursor] = useState(null);
 
             useEffect(() => {
                 fetchData();
-            }, []);
+            }, [currentCursor]);
 
             const fetchData = async () => {
                 try {
                     setLoading(true);
-                    // Use lightweight summary query - drill-down will load details on demand
                     const [testRunsData, projectsData] = await Promise.all([
-                        graphqlClient.query(GRAPHQL_QUERIES.GET_RECENT_TEST_RUNS_SUMMARY, { limit: 100 }),
+                        graphqlClient.query(GRAPHQL_QUERIES.GET_TEST_RUNS_PAGINATED, { first: 50, after: currentCursor }),
                         graphqlClient.query(GRAPHQL_QUERIES.GET_PROJECTS_LIST, { first: 100 })
                     ]);
-                    
+
                     // Get projects to map project names
                     const projectList = projectsData.projects.edges.map(edge => edge.node);
-                    
+
                     // Enrich test runs with project names and use database duration
-                    const enrichedTestRuns = (testRunsData.recentTestRuns || []).map(run => {
+                    const enrichedTestRuns = (testRunsData.testRuns?.edges || []).map(edge => {
+                        const run = edge.node;
                         const project = projectList.find(p => p.projectId === run.projectId);
-                        
+
                         // Use database duration or calculate from timestamps
                         let finalDuration = run.duration;
-                        
+
                         // Fallback: Calculate from startTime and endTime if duration is missing
                         if ((!finalDuration || finalDuration <= 0) && run.startTime && run.endTime) {
                             try {
@@ -4752,25 +4765,39 @@
                                 // Failed to parse timestamps
                             }
                         }
-                        
+
                         // Last resort: Reasonable estimate based on test count
                         if (!finalDuration && run.totalTests && run.totalTests > 0) {
                             finalDuration = run.totalTests * 100; // 100ms per test average
                         }
-                        
+
                         return {
                             ...run,
                             projectName: project?.name || run.projectId,
                             duration: finalDuration
                         };
                     });
-                    
+
                     setTestRuns(enrichedTestRuns);
+                    setPageInfo(testRunsData.testRuns?.pageInfo);
+                    setTotalCount(testRunsData.testRuns?.totalCount || 0);
                     setLoading(false);
                 } catch (err) {
                     console.error('Error fetching test runs:', err);
                     setError(err.message);
                     setLoading(false);
+                }
+            };
+
+            const handleNextPage = () => {
+                if (pageInfo?.hasNextPage) {
+                    setCurrentCursor(pageInfo.endCursor);
+                }
+            };
+
+            const handlePreviousPage = () => {
+                if (currentCursor) {
+                    setCurrentCursor(null); // For now, go back to first page
                 }
             };
 
@@ -5133,6 +5160,51 @@
                                         ))}
                                     </tbody>
                                 </table>
+                                {/* Pagination Controls */}
+                                {pageInfo && (
+                                    <div style={{
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                        alignItems: 'center',
+                                        padding: '1rem',
+                                        borderTop: '1px solid var(--border-color)',
+                                        marginTop: '1rem'
+                                    }}>
+                                        <div style={{fontSize: '0.875rem', color: 'var(--text-secondary)'}}>
+                                            Showing {testRuns.length} of {totalCount} test runs
+                                        </div>
+                                        <div style={{display: 'flex', gap: '0.5rem'}}>
+                                            <button
+                                                onClick={handlePreviousPage}
+                                                disabled={!currentCursor}
+                                                style={{
+                                                    padding: '0.5rem 1rem',
+                                                    borderRadius: 'var(--radius-md)',
+                                                    border: '1px solid var(--border-color)',
+                                                    background: 'var(--bg-secondary)',
+                                                    cursor: !currentCursor ? 'not-allowed' : 'pointer',
+                                                    opacity: !currentCursor ? 0.5 : 1
+                                                }}
+                                            >
+                                                <i className="fas fa-chevron-left"></i> Previous
+                                            </button>
+                                            <button
+                                                onClick={handleNextPage}
+                                                disabled={!pageInfo.hasNextPage}
+                                                style={{
+                                                    padding: '0.5rem 1rem',
+                                                    borderRadius: 'var(--radius-md)',
+                                                    border: '1px solid var(--border-color)',
+                                                    background: 'var(--bg-secondary)',
+                                                    cursor: !pageInfo.hasNextPage ? 'not-allowed' : 'pointer',
+                                                    opacity: !pageInfo.hasNextPage ? 0.5 : 1
+                                                }}
+                                            >
+                                                Next <i className="fas fa-chevron-right"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         ) : (
                             <div className="empty-state">

--- a/web/js/graphql-client.js
+++ b/web/js/graphql-client.js
@@ -191,6 +191,43 @@ const QUERIES = {
         }
     `,
 
+    GET_TEST_RUNS_PAGINATED: `
+        query GetTestRunsPaginated($first: Int, $after: String, $projectId: String) {
+            testRuns(first: $first, after: $after, filter: { projectId: $projectId }) {
+                edges {
+                    node {
+                        id
+                        runId
+                        projectId
+                        branch
+                        status
+                        startTime
+                        endTime
+                        duration
+                        totalTests
+                        passedTests
+                        failedTests
+                        skippedTests
+                        tags {
+                            id
+                            name
+                            category
+                            value
+                        }
+                    }
+                    cursor
+                }
+                pageInfo {
+                    hasNextPage
+                    hasPreviousPage
+                    startCursor
+                    endCursor
+                }
+                totalCount
+            }
+        }
+    `,
+
     GET_TREEMAP_DATA: `
         query GetTreemapData($projectId: String, $days: Int) {
             treemapData(projectId: $projectId, days: $days) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lock down write endpoints and add pagination for test runs across the stack. All POST/PUT result submissions now require an auth token, and the dashboard loads test runs via a paginated GraphQL connection for faster pages.

- **New Features**
  - End-to-end pagination: repository `Count`/`List`, service `ListTestRuns`/`CountTestRuns`, GraphQL `testRuns` with cursor pagination (default 50 per page, up to 200), and web uses `GET_TEST_RUNS_PAGINATED` with next/previous controls and total count. Also normalizes hash URLs to improve SPA back button behavior.

- **Bug Fixes**
  - Moved all write routes under auth middleware. The following now require a token: POST `/api/v1/test-runs`, `/test-runs/start`, `/test-runs/complete`, `/suite-runs`, `/spec-runs`, and PUT `/api/v1/test-runs/:id`.

<sup>Written for commit 38b3f1d9568083f7ac05267077413b31fd9ac5ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

