### PR TITLE
fix: allow admin to assign projects to any group (#152)

### DIFF
--- a/acceptance/projects/projects_test.go
+++ b/acceptance/projects/projects_test.go
@@ -75,7 +75,9 @@ var _ = Describe("UC-04-05: Team Assignment for Projects", Label("e2e"), func() 
 		Expect(teamInput).To(BeVisible())
 
 		datalist := page.Locator("datalist#teams-datalist")
-		Expect(datalist).To(BeVisible())
+		count, err := datalist.Count()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
 	})
 
 	It("should allow typing a free-form team name not in the suggestion list", func() {

--- a/web/index.html
+++ b/web/index.html
@@ -6695,26 +6695,48 @@
                                 <label style={{display: 'block', marginBottom: '0.5rem', fontWeight: '500'}}>
                                     Team
                                 </label>
-                                <input
-                                    type="text"
-                                    list="teams-datalist"
-                                    value={formData.team}
-                                    onChange={(e) => setFormData({...formData, team: e.target.value})}
-                                    placeholder={isAdmin ? "Type or select a team (leave blank for no team)" : "Type or select a team"}
-                                    style={{
-                                        width: '100%',
-                                        padding: '0.75rem',
-                                        border: '1px solid var(--border-color)',
-                                        borderRadius: 'var(--radius-md)',
-                                        background: 'var(--bg-secondary)',
-                                        color: 'var(--text-primary)'
-                                    }}
-                                />
-                                <datalist id="teams-datalist">
-                                    {teams.map(team => (
-                                        <option key={team} value={team} />
-                                    ))}
-                                </datalist>
+                                {isAdmin ? (
+                                    <>
+                                        <input
+                                            type="text"
+                                            list="teams-datalist"
+                                            value={formData.team}
+                                            onChange={(e) => setFormData({...formData, team: e.target.value})}
+                                            placeholder="Type or select a team (leave blank for no team)"
+                                            style={{
+                                                width: '100%',
+                                                padding: '0.75rem',
+                                                border: '1px solid var(--border-color)',
+                                                borderRadius: 'var(--radius-md)',
+                                                background: 'var(--bg-secondary)',
+                                                color: 'var(--text-primary)'
+                                            }}
+                                        />
+                                        <datalist id="teams-datalist">
+                                            {teams.map(team => (
+                                                <option key={team} value={team} />
+                                            ))}
+                                        </datalist>
+                                    </>
+                                ) : (
+                                    <select
+                                        value={formData.team}
+                                        onChange={(e) => setFormData({...formData, team: e.target.value})}
+                                        style={{
+                                            width: '100%',
+                                            padding: '0.75rem',
+                                            border: '1px solid var(--border-color)',
+                                            borderRadius: 'var(--radius-md)',
+                                            background: 'var(--bg-secondary)',
+                                            color: 'var(--text-primary)'
+                                        }}
+                                    >
+                                        <option value="">Select a team</option>
+                                        {teams.map(team => (
+                                            <option key={team} value={team}>{team}</option>
+                                        ))}
+                                    </select>
+                                )}
                             </div>
                             
                             <div style={{marginBottom: '1rem'}}>


### PR DESCRIPTION
The problem was restricting the groups dropdown to only the groups in the token. This can be free form for admins.
Replace the Team dropdown with a free-form text input backed by a datalist, so admins can assign a project to any group, including newly created ones with no existing projects. Also update E2E tests to match the new input element.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Team field to an admin-only text input with a datalist so admins can assign projects to any group or leave it blank; non-admins keep the dropdown. Removed default team selection and updated E2E tests for the new flows.

- **New Features**
  - Admins see an `input` with `list="teams-datalist"`; non-admins see a `select`.
  - No default team is auto-selected; tests updated for input rendering, free-form/new/empty team, and edit prefill.

<sup>Written for commit 693fca184e865530d4e56842a05a1e67e5e5f826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

