### PR TITLE
fix: suppress error flash before SSO redirect when unauthenticated - Closes #164

### DIFF
--- a/web/js/graphql-client.js
+++ b/web/js/graphql-client.js
@@ -6,9 +6,11 @@ class GraphQLClient {
     }
 
     async query(queryOrOptions, variables = {}) {
+        if (window._authRedirecting) return new Promise(() => {});
+
         // Handle both string queries and options objects
         let queryString, queryVariables;
-        
+
         if (typeof queryOrOptions === 'string') {
             queryString = queryOrOptions;
             queryVariables = variables;
@@ -18,9 +20,9 @@ class GraphQLClient {
         } else {
             throw new Error('Invalid query format');
         }
-        
+
         const endpoint = this.endpoint;
-        
+
         const response = await fetch(endpoint, {
             method: 'POST',
             headers: {
@@ -36,9 +38,9 @@ class GraphQLClient {
 
         if (!response.ok) {
             if (response.status === 401) {
-                // Redirect to login
+                window._authRedirecting = true;
                 window.location.href = '/auth/login';
-                return;
+                return new Promise(() => {}); // never resolves — redirect is imminent
             }
             // Try to get error details
             const errorText = await response.text();


### PR DESCRIPTION
# Prevent flashing up an error message before redirect.

Error is "Error reading properties of undefined (reading 'dashboard summary')"

Sets a window._authRedirecting flag and returns a never-resolving promise when a 401 is received, so no catch block fires and no error is displayed. Any parallel or subsequent  queries also short-circuit immediately once the flag is set.

Before this change, the redirect was triggered, but the async function returned undefined to the caller. The dashboard was using Promise.all on multiple queries, and when one resolved with undefined, the code immediately tried to access:                                                                                                                                    
                                                                                                                                                                                      
  `summaryData.dashboardSummary.health`

which is the issue.                                                                                                                
   
File changed: web/js/graphql-client.js                           


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the brief error flash when an unauthenticated user is redirected to SSO by short‑circuiting GraphQL requests on 401 and while redirecting. Fixes #164.

- **Bug Fixes**
  - On 401, set `window._authRedirecting`, start login redirect, and return a never‑resolving promise so catch handlers don’t run.
  - If `window._authRedirecting` is set, `query` immediately returns a never‑resolving promise to prevent the “dashboard summary” error.

<sup>Written for commit 9186518253b237ab94e83cc7891c1edaa933a4a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



