### PR TITLE
fix: sort team list alphabetically in project creation dialog (#167)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
     
     - name: Run govulncheck
       run: |

--- a/acceptance/projects/projects_test.go
+++ b/acceptance/projects/projects_test.go
@@ -212,6 +212,41 @@ var _ = Describe("UC-04: Project Management", Label("e2e"), func() {
 					return !projectExists
 				}, 10*time.Second).Should(BeTrue())
 			})
+
+			It("should display team options in alphabetical order in the create project dialog", func() {
+				// Open the create project modal
+				Expect(page.Click("button:has-text('New Project')")).To(Succeed())
+				_, err := page.WaitForSelector("text=Create New Project")
+				Expect(err).NotTo(HaveOccurred())
+
+				// Ensure the modal is closed even if assertions fail
+				DeferCleanup(func() {
+					page.Click("button:has-text('Cancel')")
+				})
+
+				// Scope to the dialog container so we don't pick up other selects on the page
+				dialog := page.Locator("h3:has-text('Create New Project')").Locator("xpath=..")
+
+				// Get all options from the team select (excluding the "No team" placeholder)
+				options := dialog.Locator("select option:not([value=''])")
+				count, err := options.Count()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(BeNumerically(">", 0))
+
+				teamNames := make([]string, count)
+				for i := 0; i < count; i++ {
+					text, err := options.Nth(i).InnerText()
+					Expect(err).NotTo(HaveOccurred())
+					teamNames[i] = text
+				}
+
+				// Verify the list is sorted alphabetically (case-insensitive, matching localeCompare behaviour)
+				for i := 1; i < len(teamNames); i++ {
+					Expect(strings.ToLower(teamNames[i-1]) <= strings.ToLower(teamNames[i])).To(BeTrue(),
+						"Expected teams to be sorted alphabetically, but %q comes before %q",
+						teamNames[i-1], teamNames[i])
+				}
+			})
 		})
 
 		Context("As a regular user", func() {

--- a/web/index.html
+++ b/web/index.html
@@ -6708,7 +6708,7 @@
                                     }}
                                 >
                                     {isAdmin && <option value="">No team</option>}
-                                    {teams.map(team => (
+                                    {[...teams].sort((a, b) => a.localeCompare(b)).map(team => (
                                         <option key={team} value={team}>{team}</option>
                                     ))}
                                 </select>


### PR DESCRIPTION
#  Summary

## Closes #167

  - Team names in the project creation dialog dropdown were displayed in an arbitrary order (determined by the order they appear in the user's groups)                                        
  - Sorts the team list alphabetically using localeCompare before rendering the dropdown options
  - Adds a Playwright acceptance test to verify the team dropdown options are in alphabetical order                                                                                           
                                                                                                                                                                                              
## Test plan
                                                                                                                                                                                              
  - Open the "New Project" dialog and verify teams are displayed in alphabetical order
  - Run acceptance tests: make test-acceptance (requires live environment)
  - Run unit tests: make -f Makefile.test test-unit
                                                        

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort the team dropdown alphabetically in the New Project dialog so selection is predictable and consistent. Fixes #167 and adds an acceptance test to prevent regressions.

- **Bug Fixes**
  - Sort a copy of `teams` with `localeCompare` before rendering; keep "No team" first for admins.
  - Acceptance test checks case-insensitive alphabetical order and excludes the "No team" placeholder.

- **Dependencies**
  - Pin `golang.org/x/vuln/cmd/govulncheck` to `v1.1.4` in CI.

<sup>Written for commit f84869118786aeb066d97063e305edaeb0e04fd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

