### PR TITLE
fix: prevent proxy from caching the OAuth login redirect

### DIFF
--- a/internal/domains/auth/interfaces/middleware_adapter.go
+++ b/internal/domains/auth/interfaces/middleware_adapter.go
@@ -323,6 +323,12 @@ func (m *AuthMiddlewareAdapter) StartOAuthFlow() gin.HandlerFunc {
 			return
 		}
 
+		// Prevent proxies and browsers from caching this redirect — a cached response
+		// would have the Set-Cookie header stripped, so the oauth_state cookie would
+		// never reach the browser and every subsequent login attempt would fail.
+		c.Header("Cache-Control", "no-store, no-cache, must-revalidate")
+		c.Header("Pragma", "no-cache")
+
 		// Store state in session/cookie for validation
 		isSecure := c.Request.TLS != nil || c.GetHeader("X-Forwarded-Proto") == "https"
 		c.SetCookie("oauth_state", state, 600, "/", "", isSecure, true) // 10 minutes

--- a/pkg/middleware/oauth.go
+++ b/pkg/middleware/oauth.go
@@ -259,6 +259,12 @@ func (m *OAuthMiddleware) StartOAuthFlow() gin.HandlerFunc {
 			return
 		}
 
+		// Prevent proxies and browsers from caching this redirect — a cached response
+		// would have the Set-Cookie header stripped, so the oauth_state cookie would
+		// never reach the browser and every subsequent login attempt would fail.
+		c.Header("Cache-Control", "no-store, no-cache, must-revalidate")
+		c.Header("Pragma", "no-cache")
+
 		// Store state in session/cookie for validation
 		isSecure := m.shouldUseSecureCookie(c)
 		cookieDomain := m.getCookieDomain()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent caching of the OAuth login redirect so the `oauth_state` cookie reaches the browser and logins don’t fail behind proxies/CDNs.

- **Bug Fixes**
  - Set `Cache-Control: no-store, no-cache, must-revalidate` and `Pragma: no-cache` on OAuth redirect responses in both `StartOAuthFlow` handlers.

<sup>Written for commit 7d61099cb33abea2c7f025a1e31a2b124f4adf25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

