### PR TITLE
fix: secure test run submission endpoints and add handler test coverage

### DIFF
--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -1,0 +1,324 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire-oss/fern-platform/pkg/config"
+	"github.com/guidewire-oss/fern-platform/pkg/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// authContextMiddleware injects user values into gin context to simulate authenticated requests
+func authContextMiddleware(userID, userName, userEmail, role, teamID, teamName string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("user_id", userID)
+		c.Set("user_name", userName)
+		c.Set("user_email", userEmail)
+		c.Set("role", role)
+		c.Set("team_id", teamID)
+		c.Set("team_name", teamName)
+		c.Next()
+	}
+}
+
+var _ = Describe("AuthHandler", func() {
+	var (
+		handler *AuthHandler
+		router  *gin.Engine
+		logger  *logging.Logger
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		loggingConfig := &config.LoggingConfig{Level: "info", Format: "json"}
+		var err error
+		logger, err = logging.NewLogger(loggingConfig)
+		Expect(err).NotTo(HaveOccurred())
+		// authMiddleware is nil — handler methods don't call it; only RegisterRoutes does
+		handler = NewAuthHandler(nil, logger)
+		router = gin.New()
+	})
+
+	Describe("showLoginPage", func() {
+		BeforeEach(func() {
+			router.GET("/auth/login", handler.showLoginPage)
+		})
+
+		It("should serve the login page HTML when not authenticated", func() {
+			req := httptest.NewRequest("GET", "/auth/login", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Type")).To(ContainSubstring("text/html"))
+			Expect(w.Body.String()).To(ContainSubstring("Fern Platform"))
+			Expect(w.Body.String()).To(ContainSubstring("/auth/start"))
+		})
+
+		It("should redirect to / when already authenticated", func() {
+			router2 := gin.New()
+			router2.Use(authContextMiddleware("user-1", "Alice", "alice@example.com", "user", "team-1", "Team A"))
+			router2.GET("/auth/login", handler.showLoginPage)
+
+			req := httptest.NewRequest("GET", "/auth/login", nil)
+			w := httptest.NewRecorder()
+			router2.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusFound))
+			Expect(w.Header().Get("Location")).To(Equal("/"))
+		})
+
+		It("should use return query param as cookie", func() {
+			req := httptest.NewRequest("GET", "/auth/login?return=/dashboard", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Set-Cookie")).To(ContainSubstring("auth_return_url"))
+		})
+
+		It("should use https scheme when X-Forwarded-Proto is https", func() {
+			req := httptest.NewRequest("GET", "/auth/login", nil)
+			req.Header.Set("X-Forwarded-Proto", "https")
+			req.Host = "example.com"
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Body.String()).To(ContainSubstring("https://example.com/auth/start"))
+		})
+
+		It("should use X-Forwarded-Host when present", func() {
+			req := httptest.NewRequest("GET", "/auth/login", nil)
+			req.Header.Set("X-Forwarded-Host", "proxy.example.com")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Body.String()).To(ContainSubstring("proxy.example.com/auth/start"))
+		})
+	})
+
+	Describe("getCurrentUser", func() {
+		BeforeEach(func() {
+			router.Use(authContextMiddleware("user-42", "Bob", "bob@example.com", "admin", "team-7", "Platform"))
+			router.GET("/auth/user", handler.getCurrentUser)
+		})
+
+		It("should return the current user details", func() {
+			req := httptest.NewRequest("GET", "/auth/user", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var body map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &body)).To(Succeed())
+			Expect(body["id"]).To(Equal("user-42"))
+			Expect(body["name"]).To(Equal("Bob"))
+			Expect(body["email"]).To(Equal("bob@example.com"))
+			Expect(body["role"]).To(Equal("admin"))
+
+			team := body["team"].(map[string]interface{})
+			Expect(team["id"]).To(Equal("team-7"))
+			Expect(team["name"]).To(Equal("Platform"))
+		})
+	})
+
+	Describe("getUserPreferences", func() {
+		BeforeEach(func() {
+			router.Use(authContextMiddleware("user-1", "Alice", "alice@example.com", "user", "team-1", "Team A"))
+			router.GET("/api/v1/user/preferences", handler.getUserPreferences)
+		})
+
+		It("should return default preferences", func() {
+			req := httptest.NewRequest("GET", "/api/v1/user/preferences", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var body map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &body)).To(Succeed())
+			Expect(body["user_id"]).To(Equal("user-1"))
+			Expect(body["theme"]).To(Equal("light"))
+
+			notifications := body["notifications"].(map[string]interface{})
+			Expect(notifications["email"]).To(BeTrue())
+
+			dashboard := body["dashboard"].(map[string]interface{})
+			Expect(dashboard["default_view"]).To(Equal("grid"))
+		})
+	})
+
+	Describe("updateUserPreferences", func() {
+		BeforeEach(func() {
+			router.Use(authContextMiddleware("user-1", "Alice", "alice@example.com", "user", "team-1", "Team A"))
+			router.PUT("/api/v1/user/preferences", handler.updateUserPreferences)
+		})
+
+		It("should echo back updated preferences", func() {
+			prefs := map[string]interface{}{"theme": "dark", "notifications": false}
+			body, _ := json.Marshal(prefs)
+
+			req := httptest.NewRequest("PUT", "/api/v1/user/preferences", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["theme"]).To(Equal("dark"))
+		})
+
+		It("should return bad request for invalid JSON", func() {
+			req := httptest.NewRequest("PUT", "/api/v1/user/preferences", bytes.NewBufferString("{invalid"))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("getUserProjects", func() {
+		BeforeEach(func() {
+			router.Use(authContextMiddleware("user-1", "Alice", "alice@example.com", "user", "team-1", "Team A"))
+			router.GET("/api/v1/user/projects", handler.getUserProjects)
+		})
+
+		It("should return empty project list", func() {
+			req := httptest.NewRequest("GET", "/api/v1/user/projects", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["total"]).To(BeNumerically("==", 0))
+			Expect(resp["items"]).To(BeEmpty())
+		})
+	})
+
+	Describe("Admin user management", func() {
+		BeforeEach(func() {
+			router.Use(authContextMiddleware("admin-1", "Admin", "admin@example.com", "admin", "team-1", "Admin Team"))
+			router.GET("/admin/users", handler.listUsers)
+			router.GET("/admin/users/:userId", handler.getUser)
+			router.PUT("/admin/users/:userId/role", handler.updateUserRole)
+			router.POST("/admin/users/:userId/suspend", handler.suspendUser)
+			router.POST("/admin/users/:userId/activate", handler.activateUser)
+			router.DELETE("/admin/users/:userId", handler.deleteUser)
+		})
+
+		It("listUsers should return empty list", func() {
+			req := httptest.NewRequest("GET", "/admin/users", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["total"]).To(BeNumerically("==", 0))
+		})
+
+		It("getUser should return user with the requested ID", func() {
+			req := httptest.NewRequest("GET", "/admin/users/user-99", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["id"]).To(Equal("user-99"))
+		})
+
+		It("updateUserRole should return success message", func() {
+			req := httptest.NewRequest("PUT", "/admin/users/user-1/role", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("Role updated"))
+		})
+
+		It("suspendUser should return success message", func() {
+			req := httptest.NewRequest("POST", "/admin/users/user-1/suspend", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("suspended"))
+		})
+
+		It("activateUser should return success message", func() {
+			req := httptest.NewRequest("POST", "/admin/users/user-1/activate", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("activated"))
+		})
+
+		It("deleteUser should return success message", func() {
+			req := httptest.NewRequest("DELETE", "/admin/users/user-1", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("deleted"))
+		})
+	})
+
+	Describe("isUserAuthenticated", func() {
+		It("should return false when user_id is not in context", func() {
+			router.GET("/test", func(c *gin.Context) {
+				result := handler.isUserAuthenticated(c)
+				c.JSON(http.StatusOK, gin.H{"authenticated": result})
+			})
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["authenticated"]).To(BeFalse())
+		})
+
+		It("should return true when user_id is set in context", func() {
+			router.Use(func(c *gin.Context) {
+				c.Set("user_id", "user-1")
+				c.Next()
+			})
+			router.GET("/test", func(c *gin.Context) {
+				result := handler.isUserAuthenticated(c)
+				c.JSON(http.StatusOK, gin.H{"authenticated": result})
+			})
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["authenticated"]).To(BeTrue())
+		})
+	})
+})

--- a/internal/api/domain_handler_v2.go
+++ b/internal/api/domain_handler_v2.go
@@ -87,11 +87,11 @@ func (h *DomainHandlerV2) RegisterRoutes(router *gin.Engine) {
 	// Public routes (no authentication required)
 	publicGroup := v1.Group("")
 	h.healthHandler.RegisterRoutes(publicGroup)
-	h.testRunHandler.RegisterPublicRoutes(publicGroup)
 
 	// User routes (require authentication)
 	userGroup := v1.Group("")
 	userGroup.Use(h.authMiddleware.RequireAuth())
+	h.testRunHandler.RegisterSubmissionRoutes(userGroup)
 
 	// Manager routes (require manager role - admin or team manager)
 	managerGroup := v1.Group("")

--- a/internal/api/project_handler_test.go
+++ b/internal/api/project_handler_test.go
@@ -1,0 +1,519 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	projectsApp "github.com/guidewire-oss/fern-platform/internal/domains/projects/application"
+	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
+	"github.com/guidewire-oss/fern-platform/pkg/config"
+	"github.com/guidewire-oss/fern-platform/pkg/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockProjectRepository mocks domain.ProjectRepository
+type MockProjectRepository struct {
+	mock.Mock
+}
+
+func (m *MockProjectRepository) Save(ctx context.Context, project *projectsDomain.Project) error {
+	return m.Called(ctx, project).Error(0)
+}
+
+func (m *MockProjectRepository) FindByID(ctx context.Context, id uint) (*projectsDomain.Project, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*projectsDomain.Project), args.Error(1)
+}
+
+func (m *MockProjectRepository) FindByProjectID(ctx context.Context, projectID projectsDomain.ProjectID) (*projectsDomain.Project, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*projectsDomain.Project), args.Error(1)
+}
+
+func (m *MockProjectRepository) FindByTeam(ctx context.Context, team projectsDomain.Team) ([]*projectsDomain.Project, error) {
+	args := m.Called(ctx, team)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*projectsDomain.Project), args.Error(1)
+}
+
+func (m *MockProjectRepository) FindAll(ctx context.Context, limit, offset int) ([]*projectsDomain.Project, int64, error) {
+	args := m.Called(ctx, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*projectsDomain.Project), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockProjectRepository) Update(ctx context.Context, project *projectsDomain.Project) error {
+	return m.Called(ctx, project).Error(0)
+}
+
+func (m *MockProjectRepository) Delete(ctx context.Context, id uint) error {
+	return m.Called(ctx, id).Error(0)
+}
+
+func (m *MockProjectRepository) ExistsByProjectID(ctx context.Context, projectID projectsDomain.ProjectID) (bool, error) {
+	args := m.Called(ctx, projectID)
+	return args.Bool(0), args.Error(1)
+}
+
+// MockProjectPermissionRepository mocks domain.ProjectPermissionRepository
+type MockProjectPermissionRepository struct {
+	mock.Mock
+}
+
+func (m *MockProjectPermissionRepository) Save(ctx context.Context, permission *projectsDomain.ProjectPermission) error {
+	return m.Called(ctx, permission).Error(0)
+}
+
+func (m *MockProjectPermissionRepository) FindByProjectAndUser(ctx context.Context, projectID projectsDomain.ProjectID, userID string) ([]*projectsDomain.ProjectPermission, error) {
+	args := m.Called(ctx, projectID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*projectsDomain.ProjectPermission), args.Error(1)
+}
+
+func (m *MockProjectPermissionRepository) FindByUser(ctx context.Context, userID string) ([]*projectsDomain.ProjectPermission, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*projectsDomain.ProjectPermission), args.Error(1)
+}
+
+func (m *MockProjectPermissionRepository) FindByProject(ctx context.Context, projectID projectsDomain.ProjectID) ([]*projectsDomain.ProjectPermission, error) {
+	args := m.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*projectsDomain.ProjectPermission), args.Error(1)
+}
+
+func (m *MockProjectPermissionRepository) Delete(ctx context.Context, projectID projectsDomain.ProjectID, userID string, permission projectsDomain.PermissionType) error {
+	return m.Called(ctx, projectID, userID, permission).Error(0)
+}
+
+func (m *MockProjectPermissionRepository) DeleteExpired(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+
+// newTestProject is a helper that builds a domain project for use in tests
+func newTestProject(projectID, name, team string) *projectsDomain.Project {
+	p, err := projectsDomain.NewProject(projectsDomain.ProjectID(projectID), name, projectsDomain.Team(team))
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+var _ = Describe("ProjectHandler", func() {
+	var (
+		handler     *ProjectHandler
+		router      *gin.Engine
+		projectRepo *MockProjectRepository
+		permRepo    *MockProjectPermissionRepository
+		service     *projectsApp.ProjectService
+	)
+
+	BeforeEach(func() {
+		gin.SetMode(gin.TestMode)
+		loggingConfig := &config.LoggingConfig{Level: "info", Format: "json"}
+		logger, err := logging.NewLogger(loggingConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		projectRepo = new(MockProjectRepository)
+		permRepo = new(MockProjectPermissionRepository)
+		service = projectsApp.NewProjectService(projectRepo, permRepo)
+		handler = NewProjectHandler(service, logger)
+
+		router = gin.New()
+		router.Use(authContextMiddleware("user-1", "Alice", "alice@example.com", "manager", "team-1", "Team A"))
+
+		userGroup := router.Group("/api/v1")
+		managerGroup := router.Group("/api/v1")
+		adminGroup := router.Group("/api/v1/admin")
+		handler.RegisterRoutes(userGroup, managerGroup, adminGroup)
+	})
+
+	Describe("createProject", func() {
+		It("should create a project successfully", func() {
+			projectRepo.On("ExistsByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(false, nil).Once()
+			projectRepo.On("Save", mock.Anything, mock.Anything).Return(nil).Once()
+			permRepo.On("Save", mock.Anything, mock.Anything).Return(nil).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{
+				"projectId": "proj-1",
+				"name":      "My Project",
+				"team":      "platform",
+			})
+			req := httptest.NewRequest("POST", "/api/v1/projects", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusCreated))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["projectId"]).To(Equal("proj-1"))
+			Expect(resp["name"]).To(Equal("My Project"))
+			Expect(resp["team"]).To(Equal("platform"))
+		})
+
+		It("should generate a project ID when not provided", func() {
+			projectRepo.On("ExistsByProjectID", mock.Anything, mock.Anything).Return(false, nil).Once()
+			projectRepo.On("Save", mock.Anything, mock.Anything).Return(nil).Once()
+			permRepo.On("Save", mock.Anything, mock.Anything).Return(nil).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{
+				"name": "Auto ID Project",
+				"team": "platform",
+			})
+			req := httptest.NewRequest("POST", "/api/v1/projects", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusCreated))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["projectId"]).NotTo(BeEmpty())
+		})
+
+		It("should update additional fields after creation", func() {
+			projectRepo.On("ExistsByProjectID", mock.Anything, mock.Anything).Return(false, nil).Once()
+			projectRepo.On("Save", mock.Anything, mock.Anything).Return(nil).Once()
+			permRepo.On("Save", mock.Anything, mock.Anything).Return(nil).Once()
+			projectRepo.On("FindByProjectID", mock.Anything, mock.Anything).Return(newTestProject("proj-2", "Repo Project", "platform"), nil).Once()
+			projectRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{
+				"projectId":   "proj-2",
+				"name":        "Repo Project",
+				"team":        "platform",
+				"description": "A project with extras",
+				"repository":  "https://github.com/org/repo",
+			})
+			req := httptest.NewRequest("POST", "/api/v1/projects", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusCreated))
+		})
+
+		It("should return 400 for missing required fields", func() {
+			body, _ := json.Marshal(map[string]interface{}{"name": "No Team"})
+			req := httptest.NewRequest("POST", "/api/v1/projects", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should return 500 when service fails", func() {
+			projectRepo.On("ExistsByProjectID", mock.Anything, mock.Anything).Return(false, nil).Once()
+			projectRepo.On("Save", mock.Anything, mock.Anything).Return(errors.New("db error")).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{"name": "Fail Project", "team": "platform"})
+			req := httptest.NewRequest("POST", "/api/v1/projects", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("getProject", func() {
+		It("should return a project by string project ID", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("my-project")).
+				Return(newTestProject("my-project", "My Project", "platform"), nil).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects/my-project", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["projectId"]).To(Equal("my-project"))
+		})
+
+		It("should return 501 for a numeric ID", func() {
+			req := httptest.NewRequest("GET", "/api/v1/projects/42", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotImplemented))
+		})
+
+		It("should return 404 when project not found", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("missing")).
+				Return(nil, projectsDomain.ErrProjectNotFound).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects/missing", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("getProjectByProjectID", func() {
+		It("should return a project", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-abc")).
+				Return(newTestProject("proj-abc", "ABC Project", "team-x"), nil).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects/by-project-id/proj-abc", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["projectId"]).To(Equal("proj-abc"))
+		})
+
+		It("should return 404 when project not found", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("missing")).
+				Return(nil, projectsDomain.ErrProjectNotFound).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects/by-project-id/missing", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("updateProject", func() {
+		It("should update a project successfully", func() {
+			p := newTestProject("proj-1", "Old Name", "platform")
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(p, nil).Twice()
+			projectRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{"name": "New Name"})
+			req := httptest.NewRequest("PUT", "/api/v1/projects/proj-1", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["name"]).To(Equal("New Name"))
+		})
+
+		It("should return 500 when update service fails", func() {
+			p := newTestProject("proj-1", "Old Name", "platform")
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(p, nil).Once()
+			projectRepo.On("Update", mock.Anything, mock.Anything).Return(errors.New("db error")).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{"name": "New Name"})
+			req := httptest.NewRequest("PUT", "/api/v1/projects/proj-1", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+
+		It("should return 500 when get-after-update fails", func() {
+			p := newTestProject("proj-1", "Old Name", "platform")
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(p, nil).Once()
+			projectRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(nil, errors.New("db error")).Once()
+
+			body, _ := json.Marshal(map[string]interface{}{"name": "New Name"})
+			req := httptest.NewRequest("PUT", "/api/v1/projects/proj-1", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("deleteProject", func() {
+		It("should delete a project successfully", func() {
+			p := newTestProject("proj-1", "My Project", "platform")
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(p, nil).Once()
+			projectRepo.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+
+			req := httptest.NewRequest("DELETE", "/api/v1/projects/proj-1", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("deleted"))
+		})
+
+		It("should return 500 when delete fails", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(nil, errors.New("not found")).Once()
+
+			req := httptest.NewRequest("DELETE", "/api/v1/projects/proj-1", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("listProjects", func() {
+		It("should list projects with default pagination", func() {
+			projects := []*projectsDomain.Project{
+				newTestProject("proj-1", "Project 1", "team-a"),
+				newTestProject("proj-2", "Project 2", "team-b"),
+			}
+			projectRepo.On("FindAll", mock.Anything, 20, 0).Return(projects, int64(2), nil).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("X-Total-Count")).To(Equal("2"))
+			var resp []interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp).To(HaveLen(2))
+		})
+
+		It("should respect limit and offset query params", func() {
+			projectRepo.On("FindAll", mock.Anything, 5, 10).Return([]*projectsDomain.Project{}, int64(0), nil).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects?limit=5&offset=10", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			projectRepo.AssertExpectations(GinkgoT())
+		})
+
+		It("should return 500 when service fails", func() {
+			projectRepo.On("FindAll", mock.Anything, mock.Anything, mock.Anything).Return(nil, int64(0), errors.New("db error")).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/projects", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("activateProject", func() {
+		It("should activate a project", func() {
+			p := newTestProject("proj-1", "My Project", "platform")
+			p.Deactivate()
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(p, nil).Once()
+			projectRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
+
+			req := httptest.NewRequest("POST", "/api/v1/projects/proj-1/activate", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("activated"))
+		})
+
+		It("should return 500 when activate fails", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(nil, errors.New("not found")).Once()
+
+			req := httptest.NewRequest("POST", "/api/v1/projects/proj-1/activate", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("deactivateProject", func() {
+		It("should deactivate a project", func() {
+			p := newTestProject("proj-1", "My Project", "platform")
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(p, nil).Once()
+			projectRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
+
+			req := httptest.NewRequest("POST", "/api/v1/projects/proj-1/deactivate", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["message"]).To(ContainSubstring("deactivated"))
+		})
+
+		It("should return 500 when deactivate fails", func() {
+			projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("proj-1")).Return(nil, errors.New("not found")).Once()
+
+			req := httptest.NewRequest("POST", "/api/v1/projects/proj-1/deactivate", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("getProjectStats", func() {
+		It("should return placeholder stats for a project", func() {
+			req := httptest.NewRequest("GET", "/api/v1/projects/stats/proj-1", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["projectId"]).To(Equal("proj-1"))
+			Expect(resp["totalTestRuns"]).To(BeNumerically("==", 0))
+		})
+	})
+
+	Describe("admin endpoints", func() {
+		It("grantProjectAccess should return 501", func() {
+			req := httptest.NewRequest("POST", "/api/v1/admin/projects/proj-1/users/user-1/access", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotImplemented))
+		})
+
+		It("revokeProjectAccess should return 501", func() {
+			req := httptest.NewRequest("DELETE", "/api/v1/admin/projects/proj-1/users/user-1/access", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusNotImplemented))
+		})
+
+		It("getProjectUsers should return empty list", func() {
+			req := httptest.NewRequest("GET", "/api/v1/admin/projects/proj-1/users", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp map[string]interface{}
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+			Expect(resp["users"]).To(BeEmpty())
+		})
+	})
+})

--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -885,13 +885,13 @@ func (h *TestRunHandler) RegisterRoutes(userGroup, adminGroup *gin.RouterGroup) 
 	adminGroup.POST("/test-runs/bulk-delete", h.bulkDeleteTestRuns)
 }
 
-// RegisterPublicRoutes registers public (unauthenticated) test submission routes
+// RegisterSubmissionRoutes registers authenticated test submission routes
 // These are compatible with the legacy Fern Reporter API
-func (h *TestRunHandler) RegisterPublicRoutes(publicGroup *gin.RouterGroup) {
-	publicGroup.POST("/test-runs", h.recordTestRun)
-	publicGroup.POST("/test-runs/start", h.startTestRun)
-	publicGroup.POST("/test-runs/complete", h.completeTestRun)
-	publicGroup.POST("/suite-runs", h.addSuiteRun)
-	publicGroup.POST("/spec-runs", h.addSpecRun)
-	publicGroup.PUT("/test-runs/:id", h.updateTestRunPublic)
+func (h *TestRunHandler) RegisterSubmissionRoutes(userGroup *gin.RouterGroup) {
+	userGroup.POST("/test-runs", h.recordTestRun)
+	userGroup.POST("/test-runs/start", h.startTestRun)
+	userGroup.POST("/test-runs/complete", h.completeTestRun)
+	userGroup.POST("/suite-runs", h.addSuiteRun)
+	userGroup.POST("/spec-runs", h.addSpecRun)
+	userGroup.PUT("/test-runs/:id", h.updateTestRunPublic)
 }

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -1422,7 +1422,7 @@ var _ = Describe("TestRunHandler", func() {
 		BeforeEach(func() {
 			publicRouter = gin.New()
 			publicGroup = publicRouter.Group("/api/v1")
-			handler.RegisterPublicRoutes(publicGroup)
+			handler.RegisterSubmissionRoutes(publicGroup)
 		})
 
 		Describe("recordTestRun", func() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Secure the test run submission endpoints by requiring authentication and registering them under the authenticated `/api/v1` user group. Adds handler tests for auth (login, user, prefs, admin users), projects (CRUD, list, activate/deactivate, stats), and test run submissions.

- **Bug Fixes**
  - Require auth for submission routes: `POST /test-runs`, `POST /test-runs/start`, `POST /test-runs/complete`, `POST /suite-runs`, `POST /spec-runs`, `PUT /test-runs/:id`.
  - Replace `RegisterPublicRoutes` with `RegisterSubmissionRoutes` and register these routes on the authenticated user group in `DomainHandlerV2`.

- **Migration**
  - Clients/reporters must include a valid auth token when calling the submission endpoints.
  - Unauthenticated calls to these routes are no longer accepted.

<sup>Written for commit 65aea4807544fb3f6b5b522026a0e6af71255beb. Summary will update on new commits. <a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/171?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

