### PR TITLE
fix(api): return user-friendly error for non-existent projectID (#117)

### DIFF
--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -601,11 +601,15 @@ func (h *TestRunHandler) recordTestRun(c *gin.Context) {
 		createdTestRun, alreadyExisted, err := h.testingService.CreateTestRun(c.Request.Context(), newTestRun)
 		h.logger.Debug("Test run creation result", "alreadyExisted", alreadyExisted, "runID", runID)
 		if err != nil {
+			if errors.Is(err, projectsDomain.ErrProjectNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("project '%s' not found", req.TestProjectID)})
+				return
+			}
 			if errors.Is(err, domain.ErrInvalidTestRun) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create test run"})
 			return
 		}
 
@@ -705,7 +709,11 @@ func (h *TestRunHandler) startTestRun(c *gin.Context) {
 
 	_, _, err := h.testingService.CreateTestRun(c.Request.Context(), testRun)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("project '%s' not found", req.ProjectID)})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create test run"})
 		return
 	}
 

--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -580,6 +580,16 @@ func (h *TestRunHandler) recordTestRun(c *gin.Context) {
 	}
 
 	if testRun == nil {
+		if _, err := h.projectService.GetProject(c.Request.Context(), projectsDomain.ProjectID(req.TestProjectID)); err != nil {
+			if errors.Is(err, projectsDomain.ErrProjectNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("project '%s' not found", req.TestProjectID)})
+				return
+			}
+			h.logger.WithError(err).Error("Failed to validate project")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to validate project"})
+			return
+		}
+
 		// brand new run
 		newTestRun := &domain.TestRun{
 			RunID:        runID,
@@ -705,6 +715,16 @@ func (h *TestRunHandler) startTestRun(c *gin.Context) {
 		Status:      "running",
 		StartTime:   time.Now(),
 		Metadata:    req.Metadata,
+	}
+
+	if _, err := h.projectService.GetProject(c.Request.Context(), projectsDomain.ProjectID(req.ProjectID)); err != nil {
+		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("project '%s' not found", req.ProjectID)})
+			return
+		}
+		h.logger.WithError(err).Error("Failed to validate project")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to validate project"})
+		return
 	}
 
 	_, _, err := h.testingService.CreateTestRun(c.Request.Context(), testRun)

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -1515,6 +1515,10 @@ var _ = Describe("TestRunHandler", func() {
 				}
 				jsonBody, _ := json.Marshal(req)
 
+				project, err := projectsDomain.NewProject(projectsDomain.ProjectID("project-123"), "Test Project", projectsDomain.Team("team-1"))
+				Expect(err).NotTo(HaveOccurred())
+				projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("project-123")).Return(project, nil).Once()
+
 				testRunRepo.On("Create", mock.Anything, mock.Anything).Return(nil)
 				testRunRepo.On("GetByRunID", mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
 				suiteRunRepo.On("Create", mock.Anything, mock.Anything).Return(nil)
@@ -1555,6 +1559,10 @@ var _ = Describe("TestRunHandler", func() {
 
 				jsonBody, _ := json.Marshal(req)
 
+				project, err := projectsDomain.NewProject(projectsDomain.ProjectID("project-123"), "Test Project", projectsDomain.Team("team-1"))
+				Expect(err).NotTo(HaveOccurred())
+				projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("project-123")).Return(project, nil).Once()
+
 				httpReq := httptest.NewRequest("POST", "/api/v1/test-runs", bytes.NewBuffer(jsonBody))
 				httpReq.Header.Set("Content-Type", "application/json")
 				w := httptest.NewRecorder()
@@ -1563,7 +1571,7 @@ var _ = Describe("TestRunHandler", func() {
 				Expect(w.Code).To(Equal(http.StatusBadRequest))
 
 				var response map[string]interface{}
-				err := json.Unmarshal(w.Body.Bytes(), &response)
+				err = json.Unmarshal(w.Body.Bytes(), &response)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(response["error"]).To(ContainSubstring("invalid test run"))
@@ -1579,6 +1587,10 @@ var _ = Describe("TestRunHandler", func() {
 				}
 				jsonBody, _ := json.Marshal(req)
 
+				project, err := projectsDomain.NewProject(projectsDomain.ProjectID("project-123"), "Test Project", projectsDomain.Team("team-1"))
+				Expect(err).NotTo(HaveOccurred())
+				projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("project-123")).Return(project, nil).Once()
+
 				testRunRepo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
 
 				httpReq := httptest.NewRequest("POST", "/api/v1/test-runs/start", bytes.NewBuffer(jsonBody))
@@ -1589,7 +1601,7 @@ var _ = Describe("TestRunHandler", func() {
 				Expect(w.Code).To(Equal(http.StatusCreated))
 
 				var response map[string]interface{}
-				err := json.Unmarshal(w.Body.Bytes(), &response)
+				err = json.Unmarshal(w.Body.Bytes(), &response)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(response).To(HaveKey("id"))
 				Expect(response).To(HaveKey("runId"))
@@ -1614,6 +1626,10 @@ var _ = Describe("TestRunHandler", func() {
 					"projectId": "project-123",
 				}
 				jsonBody, _ := json.Marshal(req)
+
+				project, err := projectsDomain.NewProject(projectsDomain.ProjectID("project-123"), "Test Project", projectsDomain.Team("team-1"))
+				Expect(err).NotTo(HaveOccurred())
+				projectRepo.On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("project-123")).Return(project, nil).Once()
 
 				testRunRepo.On("Create", mock.Anything, mock.MatchedBy(func(tr *domain.TestRun) bool {
 					return tr.RunID != ""

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
 	"github.com/guidewire-oss/fern-platform/pkg/database"
 	"gorm.io/gorm"
@@ -91,8 +92,15 @@ func (s *TestRunService) CreateTestRun(ctx context.Context, testRun *domain.Test
 
 	// Create the test run
 	if err := s.testRunRepo.Create(ctx, testRun); err != nil {
-		// Check if it's a unique constraint violation (concurrent thread created it)
 		errStr := strings.ToLower(err.Error())
+
+		// Check if it's a foreign key violation on project_id (non-existent project)
+		if strings.Contains(errStr, "foreign key") || strings.Contains(errStr, "fk_test_runs_project_id") ||
+			strings.Contains(errStr, "23503") {
+			return nil, false, fmt.Errorf("%w: %s", projectsDomain.ErrProjectNotFound, testRun.ProjectID)
+		}
+
+		// Check if it's a unique constraint violation (concurrent thread created it)
 		if strings.Contains(errStr, "unique") || strings.Contains(errStr, "duplicate") {
 			// Another thread already created this test run
 			// Try to fetch the existing one


### PR DESCRIPTION
Detect FK constraint violations when creating test runs with invalid project IDs and return 404 with a clean error message instead of leaking raw Postgres internals (table names, constraint names, SQLSTATE).

Fixes #117

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 with a clear message when creating or starting a test run with a non-existent project ID, with early project validation in the API. Hide Postgres constraint details and return clear 500s for unexpected errors.

- **Bug Fixes**
  - Map FK violations in `TestRunService.CreateTestRun` to `projectsDomain.ErrProjectNotFound` by detecting "foreign key", `fk_test_runs_project_id`, or SQLSTATE `23503`.
  - Pre-check project existence in `recordTestRun` and `startTestRun`; return 404 "project '<id>' not found" when missing, 500 "failed to validate project" on lookup errors, and 500 "failed to create test run" for other creation failures.

<sup>Written for commit 2f131f2829663c4811e3283df324abd78a903cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

