### PR TITLE
fix(api): validate test run spec name lengths to handle overflow

### DIFF
--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -88,7 +87,7 @@ func (h *TestRunHandler) createTestRun(c *gin.Context) {
 
 	// Create test run using domain service
 	if _, _, err := h.testingService.CreateTestRun(c.Request.Context(), testRun); err != nil {
-		if strings.Contains(err.Error(), "invalid test run") {
+		if errors.Is(err, domain.ErrInvalidTestRun) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -602,7 +601,7 @@ func (h *TestRunHandler) recordTestRun(c *gin.Context) {
 		createdTestRun, alreadyExisted, err := h.testingService.CreateTestRun(c.Request.Context(), newTestRun)
 		h.logger.Debug("Test run creation result", "alreadyExisted", alreadyExisted, "runID", runID)
 		if err != nil {
-			if strings.Contains(err.Error(), "invalid test run") {
+			if errors.Is(err, domain.ErrInvalidTestRun) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}

--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	projectsApp "github.com/guidewire-oss/fern-platform/internal/domains/projects/application"
+	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
 	tagsApp "github.com/guidewire-oss/fern-platform/internal/domains/tags/application"
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/application"
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
-	projectsApp "github.com/guidewire-oss/fern-platform/internal/domains/projects/application"
-	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 )
 
@@ -87,6 +88,10 @@ func (h *TestRunHandler) createTestRun(c *gin.Context) {
 
 	// Create test run using domain service
 	if _, _, err := h.testingService.CreateTestRun(c.Request.Context(), testRun); err != nil {
+		if strings.Contains(err.Error(), "invalid test run") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 		h.logger.WithError(err).Error("Failed to create test run")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -516,8 +521,6 @@ func convertTestRunToAPI(tr *domain.TestRun) gin.H {
 		"updatedAt":    tr.EndTime,
 	}
 }
-
-
 
 // --- Public (unauthenticated) test submission endpoints ---
 // These are compatible with the legacy Fern Reporter API

--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -602,6 +602,10 @@ func (h *TestRunHandler) recordTestRun(c *gin.Context) {
 		createdTestRun, alreadyExisted, err := h.testingService.CreateTestRun(c.Request.Context(), newTestRun)
 		h.logger.Debug("Test run creation result", "alreadyExisted", alreadyExisted, "runID", runID)
 		if err != nil {
+			if strings.Contains(err.Error(), "invalid test run") {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -347,7 +347,7 @@ var _ = Describe("TestRunHandler", func() {
 
 			testRunRepo.
 				On("Create", mock.Anything, mock.Anything).
-				Return(errors.New("invalid test run: spec name too long")).
+				Return(fmt.Errorf("%w: spec name too long", domain.ErrInvalidTestRun)).
 				Once()
 
 			requestBody := map[string]interface{}{

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	tagsApp "github.com/guidewire-oss/fern-platform/internal/domains/tags/application"
 	projectsApp "github.com/guidewire-oss/fern-platform/internal/domains/projects/application"
 	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
-	testMocks "github.com/guidewire-oss/fern-platform/internal/testhelpers"
+	tagsApp "github.com/guidewire-oss/fern-platform/internal/domains/tags/application"
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/application"
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
+	testMocks "github.com/guidewire-oss/fern-platform/internal/testhelpers"
 	"github.com/guidewire-oss/fern-platform/pkg/config"
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 	. "github.com/onsi/ginkgo/v2"
@@ -330,6 +330,45 @@ var _ = Describe("TestRunHandler", func() {
 			router.ServeHTTP(w, req)
 
 			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should return bad request when test run validation fails", func() {
+			project, err := projectsDomain.NewProject(
+				projectsDomain.ProjectID("project-123"),
+				"Test Project",
+				projectsDomain.Team("team-1"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			projectRepo.
+				On("FindByProjectID", mock.Anything, projectsDomain.ProjectID("project-123")).
+				Return(project, nil).
+				Once()
+
+			testRunRepo.
+				On("Create", mock.Anything, mock.Anything).
+				Return(errors.New("invalid test run: spec name too long")).
+				Once()
+
+			requestBody := map[string]interface{}{
+				"projectId": "project-123",
+			}
+			jsonBody, _ := json.Marshal(requestBody)
+
+			req := httptest.NewRequest("POST", "/api/v1/admin/test-runs", bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+
+			var response map[string]interface{}
+			err = json.Unmarshal(w.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(response["error"]).To(ContainSubstring("invalid test run"))
+			testRunRepo.AssertExpectations(GinkgoT())
+			projectRepo.AssertExpectations(GinkgoT())
 		})
 
 		It("should return not found when project doesn't exist", func() {

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -1504,6 +1504,39 @@ var _ = Describe("TestRunHandler", func() {
 
 				Expect(w.Code).To(Equal(http.StatusBadRequest))
 			})
+
+			It("should return bad request when test run validation fails", func() {
+				req := TestRunRequest{
+					TestProjectID: "project-123",
+					SuiteRuns: []SuiteRun{
+						{
+							SuiteName: "Suite 1",
+							SpecRuns: []SpecRun{
+								{
+									SpecDescription: string(make([]byte, 300)), // simulate long spec name
+									Status:          "passed",
+								},
+							},
+						},
+					},
+				}
+
+				jsonBody, _ := json.Marshal(req)
+
+				httpReq := httptest.NewRequest("POST", "/api/v1/test-runs", bytes.NewBuffer(jsonBody))
+				httpReq.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				publicRouter.ServeHTTP(w, httpReq)
+
+				Expect(w.Code).To(Equal(http.StatusBadRequest))
+
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(response["error"]).To(ContainSubstring("invalid test run"))
+				testRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+			})
 		})
 
 		Describe("startTestRun", func() {

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -53,13 +53,12 @@ func ValidateTestRun(testRun *domain.TestRun) error {
 				continue
 			}
 			if utf8.RuneCountInString(spec.Name) > MaxSpecNameLength {
-				return domain.GetInvalidTestRunError(
-					fmt.Sprintf(
-						"spec name exceeds %d characters (suite: %s, spec: %s)",
-						MaxSpecNameLength,
-						suite.Name,
-						spec.Name,
-					),
+				return fmt.Errorf(
+					"%w: spec name exceeds %d characters (suite: %s, spec: %s)",
+					domain.ErrInvalidTestRun,
+					MaxSpecNameLength,
+					suite.Name,
+					spec.Name,
 				)
 			}
 		}

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -260,6 +260,10 @@ func (s *TestRunService) updateSuiteStatistics(ctx context.Context, suiteRunID u
 
 // CreateTestRunWithSuites creates a test run with all its suites and specs in one transaction
 func (s *TestRunService) CreateTestRunWithSuites(ctx context.Context, testRun *domain.TestRun, suites []domain.SuiteRun) error {
+	if testRun == nil {
+		return fmt.Errorf("testRun cannot be nil")
+	}
+
 	// Validate suite runs for test spec name length
 	testRun.SuiteRuns = suites
 	if err := ValidateTestRun(testRun); err != nil {

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
 	"github.com/guidewire-oss/fern-platform/pkg/database"
@@ -51,7 +52,7 @@ func ValidateTestRun(testRun *domain.TestRun) error {
 			if spec == nil {
 				continue
 			}
-			if len(spec.Name) > MaxSpecNameLength {
+			if utf8.RuneCountInString(spec.Name) > MaxSpecNameLength {
 				return domain.GetInvalidTestRunError(
 					fmt.Sprintf(
 						"spec name exceeds %d characters (suite: %s, spec: %s)",
@@ -71,6 +72,10 @@ func ValidateTestRun(testRun *domain.TestRun) error {
 // Returns the test run (existing or newly created), a flag indicating if it already existed, and any error
 func (s *TestRunService) CreateTestRun(ctx context.Context, testRun *domain.TestRun) (*domain.TestRun, bool, error) {
 	// Validate test run
+	if testRun == nil {
+		return nil, false, fmt.Errorf("testRun cannot be nil")
+	}
+
 	if testRun.ProjectID == "" {
 		return nil, false, fmt.Errorf("project ID is required")
 	}
@@ -281,6 +286,16 @@ func (s *TestRunService) CreateTestRunWithSuites(ctx context.Context, testRun *d
 		if len(suite.SpecRuns) > 0 {
 			for _, spec := range suite.SpecRuns {
 				spec.SuiteRunID = suite.ID
+				if utf8.RuneCountInString(spec.Name) > MaxSpecNameLength {
+					return domain.GetInvalidTestRunError(
+						fmt.Sprintf(
+							"spec name exceeds %d characters (suite: %s, spec: %s)",
+							MaxSpecNameLength,
+							suite.Name,
+							spec.Name,
+						),
+					)
+				}
 			}
 			if err := s.specRunRepo.CreateBatch(ctx, suite.SpecRuns); err != nil {
 				return fmt.Errorf("failed to create spec runs: %w", err)

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -12,6 +12,10 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	MaxSpecNameLength = 255
+)
+
 // ErrNotFound is returned when a resource is not found or parent-child validation fails
 // It wraps domain.ErrNotFound for application-level error handling
 var ErrNotFound = fmt.Errorf("resource not found: %w", domain.ErrNotFound)
@@ -36,12 +40,44 @@ func NewTestRunService(
 	}
 }
 
+// ValidateTestRun does validation of test run details
+func ValidateTestRun(testRun *domain.TestRun) error {
+	if testRun == nil {
+		return fmt.Errorf("testRun cannot be nil")
+	}
+
+	for _, suite := range testRun.SuiteRuns {
+		for _, spec := range suite.SpecRuns {
+			if spec == nil {
+				continue
+			}
+			if len(spec.Name) > MaxSpecNameLength {
+				return domain.GetInvalidTestRunError(
+					fmt.Sprintf(
+						"spec name exceeds %d characters (suite: %s, spec: %s)",
+						MaxSpecNameLength,
+						suite.Name,
+						spec.Name,
+					),
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
 // CreateTestRun creates a new test run
 // Returns the test run (existing or newly created), a flag indicating if it already existed, and any error
 func (s *TestRunService) CreateTestRun(ctx context.Context, testRun *domain.TestRun) (*domain.TestRun, bool, error) {
 	// Validate test run
 	if testRun.ProjectID == "" {
 		return nil, false, fmt.Errorf("project ID is required")
+	}
+
+	// Validate individual spec names
+	if err := ValidateTestRun(testRun); err != nil {
+		return nil, false, err
 	}
 
 	// Set default values
@@ -294,7 +330,7 @@ func (s *TestRunService) CreateSpecRun(ctx context.Context, specRun *domain.Spec
 	if specRun.Status == "" {
 		specRun.Status = "pending"
 	}
-	
+
 	// Only auto-set StartTime if both StartTime and EndTime are zero
 	if specRun.StartTime.IsZero() && (specRun.EndTime == nil || specRun.EndTime.IsZero()) {
 		specRun.StartTime = time.Now()

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -261,42 +261,38 @@ func (s *TestRunService) updateSuiteStatistics(ctx context.Context, suiteRunID u
 
 // CreateTestRunWithSuites creates a test run with all its suites and specs in one transaction
 func (s *TestRunService) CreateTestRunWithSuites(ctx context.Context, testRun *domain.TestRun, suites []domain.SuiteRun) error {
-	// Create the test run
-	createdTestRun, _, err := s.CreateTestRun(ctx, testRun)
-	if err != nil {
+	// Validate suite runs for test spec name length
+	testRun.SuiteRuns = suites
+	if err := ValidateTestRun(testRun); err != nil {
 		return err
 	}
-
-	// Use the returned test run (either new or existing)
-	if createdTestRun != nil {
-		testRun = createdTestRun
-	}
+	testRun.SuiteRuns = nil
 
 	// Always add the suite runs, whether test run is new or existing
 	// This handles the concurrent creation case where another thread created the test run
 
 	// Create all suites
+	createdTestRun, _, err := s.CreateTestRun(ctx, testRun)
+	if err != nil {
+		return err
+	}
+
+	if createdTestRun != nil {
+		testRun = createdTestRun
+	}
+
+	// Create suites + specs
 	for _, suite := range suites {
 		suite.TestRunID = testRun.ID
 		if err := s.suiteRunRepo.Create(ctx, &suite); err != nil {
 			return fmt.Errorf("failed to create suite run: %w", err)
 		}
 
-		// Create specs for this suite
 		if len(suite.SpecRuns) > 0 {
 			for _, spec := range suite.SpecRuns {
 				spec.SuiteRunID = suite.ID
-				if utf8.RuneCountInString(spec.Name) > MaxSpecNameLength {
-					return domain.GetInvalidTestRunError(
-						fmt.Sprintf(
-							"spec name exceeds %d characters (suite: %s, spec: %s)",
-							MaxSpecNameLength,
-							suite.Name,
-							spec.Name,
-						),
-					)
-				}
 			}
+
 			if err := s.specRunRepo.CreateBatch(ctx, suite.SpecRuns); err != nil {
 				return fmt.Errorf("failed to create spec runs: %w", err)
 			}

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -257,6 +257,91 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			mockTestRunRepo.AssertExpectations(GinkgoT())
 		})
 
+		It("should allow test run with spec name of length less than max length", func() {
+			validName := make([]byte, 200)
+			for i := range validName {
+				validName[i] = 'a'
+			}
+
+			testRun := &domain.TestRun{
+				ProjectID: "proj-123",
+				SuiteRuns: []domain.SuiteRun{
+					{
+						Name: "suite-1",
+						SpecRuns: []*domain.SpecRun{
+							{
+								Name: string(validName),
+							},
+						},
+					},
+				},
+			}
+
+			mockTestRunRepo.On("Create", ctx, testRun).Return(nil)
+
+			result, alreadyExisted, err := service.CreateTestRun(ctx, testRun)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(alreadyExisted).To(BeFalse())
+
+			mockTestRunRepo.AssertExpectations(GinkgoT())
+		})
+
+		It("should return error when one of the spec name exceeds max length", func() {
+			longName := make([]byte, 256)
+			for i := range longName {
+				longName[i] = 'a'
+			}
+
+			testRun := &domain.TestRun{
+				ProjectID: "proj-123",
+				SuiteRuns: []domain.SuiteRun{
+					{
+						Name: "suite-1",
+						SpecRuns: []*domain.SpecRun{
+							{
+								Name: string(longName),
+							},
+						},
+					},
+				},
+			}
+
+			result, alreadyExisted, err := service.CreateTestRun(ctx, testRun)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid test run"))
+			Expect(result).To(BeNil())
+			Expect(alreadyExisted).To(BeFalse())
+
+			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+		})
+
+		It("should ignore nil spec runs during validation", func() {
+			testRun := &domain.TestRun{
+				ProjectID: "proj-123",
+				SuiteRuns: []domain.SuiteRun{
+					{
+						Name: "suite-1",
+						SpecRuns: []*domain.SpecRun{
+							nil,
+						},
+					},
+				},
+			}
+
+			mockTestRunRepo.On("Create", ctx, testRun).Return(nil)
+
+			result, alreadyExisted, err := service.CreateTestRun(ctx, testRun)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(alreadyExisted).To(BeFalse())
+
+			mockTestRunRepo.AssertExpectations(GinkgoT())
+		})
+
 		It("should return error when repository fails", func() {
 			testRun := &domain.TestRun{
 				RunID:     "test-123",

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -802,6 +802,10 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid test run"))
+
+			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
+			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+			mockSuiteRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
 			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
 		})
 

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -238,6 +239,14 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 		fixtures = testhelpers.NewFixtureBuilder()
 	})
 
+	Describe("ValidateTestRun", func() {
+		It("should return error when testRun is nil", func() {
+			err := application.ValidateTestRun(nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("testRun cannot be nil"))
+		})
+	})
+
 	Describe("CreateTestRun", func() {
 		It("should create a test run successfully", func() {
 			testRun := &domain.TestRun{
@@ -255,6 +264,15 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			Expect(err).NotTo(HaveOccurred())
 
 			mockTestRunRepo.AssertExpectations(GinkgoT())
+		})
+
+		It("should return error when testRun is nil", func() {
+			result, alreadyExisted, err := service.CreateTestRun(ctx, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("testRun cannot be nil"))
+			Expect(result).To(BeNil())
+			Expect(alreadyExisted).To(BeFalse())
 		})
 
 		It("should allow test run with spec name of length less than max length", func() {
@@ -289,10 +307,7 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 		})
 
 		It("should return error when one of the spec name exceeds max length", func() {
-			longName := make([]byte, 256)
-			for i := range longName {
-				longName[i] = 'a'
-			}
+			longName := strings.Repeat("a", 256)
 
 			testRun := &domain.TestRun{
 				ProjectID: "proj-123",
@@ -301,7 +316,35 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 						Name: "suite-1",
 						SpecRuns: []*domain.SpecRun{
 							{
-								Name: string(longName),
+								Name: longName,
+							},
+						},
+					},
+				},
+			}
+
+			result, alreadyExisted, err := service.CreateTestRun(ctx, testRun)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid test run"))
+			Expect(result).To(BeNil())
+			Expect(alreadyExisted).To(BeFalse())
+
+			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+		})
+
+		It("should validate spec name length using rune count (unicode)", func() {
+			// each "你" is 1 rune but 3 bytes
+			longName := strings.Repeat("你", 256)
+
+			testRun := &domain.TestRun{
+				ProjectID: "proj-123",
+				SuiteRuns: []domain.SuiteRun{
+					{
+						Name: "suite-1",
+						SpecRuns: []*domain.SpecRun{
+							{
+								Name: longName,
 							},
 						},
 					},
@@ -730,6 +773,36 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 
 			mockTestRunRepo.AssertExpectations(GinkgoT())
 			mockSuiteRepo.AssertExpectations(GinkgoT())
+		})
+
+		It("should return error when spec name exceeds max length in CreateTestRunWithSuites", func() {
+			longName := strings.Repeat("a", 256)
+
+			testRun := &domain.TestRun{
+				ProjectID: "proj-123",
+				RunID:     "test-123",
+				Status:    "running",
+			}
+
+			suites := []domain.SuiteRun{
+				{
+					Name: "Suite 1",
+					SpecRuns: []*domain.SpecRun{
+						{
+							Name: longName,
+						},
+					},
+				},
+			}
+
+			mockTestRunRepo.On("Create", ctx, testRun).Return(nil)
+			mockSuiteRepo.On("Create", ctx, mock.Anything).Return(nil)
+
+			err := service.CreateTestRunWithSuites(ctx, testRun, suites)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid test run"))
+			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
 		})
 
 		It("should return error when test run creation fails", func() {

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -775,6 +775,26 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			mockSuiteRepo.AssertExpectations(GinkgoT())
 		})
 
+		It("should return error when testRun is nil", func() {
+			suites := []domain.SuiteRun{
+				{
+					Name: "Suite 1",
+					SpecRuns: []*domain.SpecRun{
+						{Name: "Spec 1"},
+					},
+				},
+			}
+
+			err := service.CreateTestRunWithSuites(ctx, nil, suites)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("testRun cannot be nil"))
+
+			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+			mockSuiteRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
+		})
+
 		It("should return error when spec name exceeds max length in CreateTestRunWithSuites", func() {
 			longName := strings.Repeat("a", 256)
 

--- a/internal/domains/testing/domain/errors.go
+++ b/internal/domains/testing/domain/errors.go
@@ -2,6 +2,6 @@ package domain
 
 import "errors"
 
-func GetInvalidTestRunError(errorMsg string) error {
-	return errors.New("invalid test run, " + errorMsg)
-}
+var (
+	ErrInvalidTestRun = errors.New("invalid test run")
+)

--- a/internal/domains/testing/domain/errors.go
+++ b/internal/domains/testing/domain/errors.go
@@ -1,0 +1,7 @@
+package domain
+
+import "errors"
+
+func GetInvalidTestRunError(errorMsg string) error {
+	return errors.New("invalid test run, " + errorMsg)
+}

--- a/internal/domains/testing/interfaces/test_service_adapter.go
+++ b/internal/domains/testing/interfaces/test_service_adapter.go
@@ -3,6 +3,8 @@ package interfaces
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -244,6 +246,10 @@ func (a *TestServiceAdapter) CreateTestRunWithSuites() gin.HandlerFunc {
 
 		// Create test run with suites
 		if err := a.service.CreateTestRunWithSuites(c.Request.Context(), testRun, suites); err != nil {
+			if strings.Contains(err.Error(), "invalid test run") {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 			a.logger.WithError(err).Error("Failed to create test run with suites")
 			c.JSON(500, gin.H{"error": "Failed to create test run"})
 			return

--- a/internal/domains/testing/interfaces/test_service_adapter.go
+++ b/internal/domains/testing/interfaces/test_service_adapter.go
@@ -2,9 +2,9 @@ package interfaces
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -246,7 +246,7 @@ func (a *TestServiceAdapter) CreateTestRunWithSuites() gin.HandlerFunc {
 
 		// Create test run with suites
 		if err := a.service.CreateTestRunWithSuites(c.Request.Context(), testRun, suites); err != nil {
-			if strings.Contains(err.Error(), "invalid test run") {
+			if errors.Is(err, domain.ErrInvalidTestRun) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}


### PR DESCRIPTION
Fixes #173 
Added validation in create test run api to ensure spec names do not exceed 255 characters before DB insertion. Now returns `400` Bad Request instead of `500` Internal Server Error for invalid input which was due to constraint `varchar(255)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate test run spec names (max 255 runes) and return 400 for invalid input across all create paths to prevent DB overflow and clarify client errors.

- **Bug Fixes**
  - Add `ValidateTestRun` with rune-based checks; ignore nil specs; reject nil `testRun`.
  - Pre-validate in `CreateTestRun` and `CreateTestRunWithSuites` before any DB writes.
  - Map `domain.ErrInvalidTestRun` to HTTP 400 in admin create, public record, and adapter `CreateTestRunWithSuites`; add tests for unicode overlength, nil cases, and 400 responses.

<sup>Written for commit 16c334e1d3406ecfede5696e118a237f8b1569be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

