### PR TITLE
fix: display correct total and recent test runs

### DIFF
--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -116,6 +116,16 @@ func (m *MockTestRunRepository) CountByProjectID(ctx context.Context, projectID 
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockTestRunRepository) CountAll(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) CountSince(ctx context.Context, t time.Time) (int64, error) {
+	args := m.Called(ctx, t)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // MockSuiteRunRepository provides a mock implementation of SuiteRunRepository
 type MockSuiteRunRepository struct {
 	mock.Mock

--- a/internal/domains/testing/application/complete_test_run_test.go
+++ b/internal/domains/testing/application/complete_test_run_test.go
@@ -34,6 +34,10 @@ func (m *mockTestRunRepo) CountByProjectID(ctx context.Context, projectID string
 func (m *mockTestRunRepo) GetRecent(ctx context.Context, limit int) ([]*domain.TestRun, error) {
 	return nil, nil
 }
+func (m *mockTestRunRepo) CountAll(ctx context.Context) (int64, error) { return 0, nil }
+func (m *mockTestRunRepo) CountSince(ctx context.Context, t time.Time) (int64, error) {
+	return 0, nil
+}
 func (m *mockTestRunRepo) GetByRunID(ctx context.Context, runID string) (*domain.TestRun, error) {
 	args := m.Called(ctx, runID)
 	return args.Get(0).(*domain.TestRun), args.Error(1)

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -266,6 +266,16 @@ func (s *TestRunService) GetRecentTestRuns(ctx context.Context, limit int) ([]*d
 	return s.testRunRepo.GetRecent(ctx, limit)
 }
 
+// CountAllTestRuns returns the total number of test runs across every project.
+func (s *TestRunService) CountAllTestRuns(ctx context.Context) (int64, error) {
+	return s.testRunRepo.CountAll(ctx)
+}
+
+// CountTestRunsSince returns the number of test runs inserted at or after t (by created_at).
+func (s *TestRunService) CountTestRunsSince(ctx context.Context, t time.Time) (int64, error) {
+	return s.testRunRepo.CountSince(ctx, t)
+}
+
 // CreateSuiteRun creates a new suite run
 func (s *TestRunService) CreateSuiteRun(ctx context.Context, suiteRun *domain.SuiteRun) error {
 	if suiteRun.TestRunID == 0 {

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -139,6 +139,16 @@ func (m *MockTestRunRepository) GetRecent(ctx context.Context, limit int) ([]*do
 	return args.Get(0).([]*domain.TestRun), args.Error(1)
 }
 
+func (m *MockTestRunRepository) CountAll(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) CountSince(ctx context.Context, t time.Time) (int64, error) {
+	args := m.Called(ctx, t)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *MockTestRunRepository) GetTestRunSummary(ctx context.Context, projectID string) (*domain.TestRunSummary, error) {
 	args := m.Called(ctx, projectID)
 	if args.Get(0) == nil {

--- a/internal/domains/testing/domain/repository.go
+++ b/internal/domains/testing/domain/repository.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 // ErrNotFound is returned by repositories when a requested resource is not found
@@ -36,6 +37,12 @@ type TestRunRepository interface {
 
 	// CountByProjectID counts test runs for a project
 	CountByProjectID(ctx context.Context, projectID string) (int64, error)
+
+	// CountAll counts all test runs across every project
+	CountAll(ctx context.Context) (int64, error)
+
+	// CountSince counts test runs inserted at or after t (by created_at).
+	CountSince(ctx context.Context, t time.Time) (int64, error)
 
 	// GetRecent retrieves recent test runs across all projects
 	GetRecent(ctx context.Context, limit int) ([]*TestRun, error)

--- a/internal/domains/testing/infrastructure/gorm_test_run_repo.go
+++ b/internal/domains/testing/infrastructure/gorm_test_run_repo.go
@@ -244,6 +244,25 @@ func (r *GormTestRunRepository) CountByProjectID(ctx context.Context, projectID 
 	return count, err
 }
 
+// CountAll counts all test runs across every project
+func (r *GormTestRunRepository) CountAll(ctx context.Context) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Model(&database.TestRun{}).Count(&count).Error
+	return count, err
+}
+
+// CountSince counts test runs whose row was inserted at or after t.
+// Uses created_at (not start_time) because start_time can be zero for rows
+// written before the run actually begins; created_at is always set by GORM.
+func (r *GormTestRunRepository) CountSince(ctx context.Context, t time.Time) (int64, error) {
+	var count int64
+	err := r.db.WithContext(ctx).
+		Model(&database.TestRun{}).
+		Where("created_at >= ?", t).
+		Count(&count).Error
+	return count, err
+}
+
 // GetRecent retrieves recent test runs across all projects
 func (r *GormTestRunRepository) GetRecent(ctx context.Context, limit int) ([]*domain.TestRun, error) {
 	var dbTestRuns []database.TestRun

--- a/internal/reporter/graphql/domain_resolvers.go
+++ b/internal/reporter/graphql/domain_resolvers.go
@@ -911,8 +911,27 @@ func (r *queryResolver) DashboardSummary_domain(ctx context.Context) (*model.Das
 		r.logger.WithError(err).Error("Failed to get recent test runs for dashboard")
 	}
 
+	// Fall back to len(recentRuns) (capped at 100) if the count queries fail,
+	// so a transient DB error doesn't silently zero out the dashboard.
 	totalTestRuns := len(recentRuns)
-	recentTestRuns := len(recentRuns)
+	if totalCount, err := r.testingService.CountAllTestRuns(ctx); err != nil {
+		r.logger.WithError(err).Error("Failed to count total test runs for dashboard")
+	} else {
+		totalTestRuns = int(totalCount)
+	}
+
+	recentTestRuns := 0
+	if recentCount, err := r.testingService.CountTestRunsSince(ctx, time.Now().Add(-24*time.Hour)); err != nil {
+		r.logger.WithError(err).Error("Failed to count recent test runs for dashboard")
+		dayAgo := time.Now().Add(-24 * time.Hour)
+		for _, tr := range recentRuns {
+			if tr.StartTime.After(dayAgo) {
+				recentTestRuns++
+			}
+		}
+	} else {
+		recentTestRuns = int(recentCount)
+	}
 	overallPassRate := float64(0)
 	totalTestsExecuted := 0
 	avgDuration := 0

--- a/internal/reporter/graphql/domain_resolvers_ginkgo_test.go
+++ b/internal/reporter/graphql/domain_resolvers_ginkgo_test.go
@@ -818,6 +818,8 @@ var _ = Describe("DomainResolvers", func() {
 
 				mockProjectRepo.On("FindAll", mock.Anything, 1000, 0).Return(projects, int64(1), nil)
 				mockTestRunRepo.On("GetRecent", mock.Anything, 100).Return([]*testingDomain.TestRun{}, nil)
+				mockTestRunRepo.On("CountAll", mock.Anything).Return(int64(0), nil)
+				mockTestRunRepo.On("CountSince", mock.Anything, mock.Anything).Return(int64(0), nil)
 				mockTestRunRepo.On("GetLatestByProjectID", mock.Anything, "proj-1", 1).Return([]*testingDomain.TestRun{}, nil)
 
 				result, err := resolver.Query().(*queryResolver).DashboardSummary_domain(ctx)

--- a/internal/testhelpers/mocks.go
+++ b/internal/testhelpers/mocks.go
@@ -4,6 +4,7 @@ package testhelpers
 
 import (
 	"context"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 
@@ -252,6 +253,16 @@ func (m *MockTestRunRepository) GetLatestByProjectID(ctx context.Context, projec
 
 func (m *MockTestRunRepository) CountByProjectID(ctx context.Context, projectID string) (int64, error) {
 	args := m.Called(ctx, projectID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) CountAll(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockTestRunRepository) CountSince(ctx context.Context, t time.Time) (int64, error) {
+	args := m.Called(ctx, t)
 	return args.Get(0).(int64), args.Error(1)
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -2576,15 +2576,10 @@
         }
 
         // Modern Header component
-        function Header({ health, projects, testRuns, onOpenSettings }) {
+        function Header({ health, projects, totalTestRuns, recentTestRuns, onOpenSettings }) {
             const { theme, toggleTheme } = useUserPreferences();
             const { user, loading, login, logout } = useAuth();
             const activeProjects = projects.filter(p => p.isActive).length;
-            const recentRuns = testRuns.filter(tr => {
-                const runDate = new Date(tr.startTime);
-                const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-                return runDate > dayAgo;
-            }).length;
 
             const getThemeIcon = () => {
                 switch (theme) {
@@ -2635,11 +2630,11 @@
                                     <span className="stat-label">Active Projects</span>
                                 </div>
                                 <div className="stat-item">
-                                    <span className="stat-value">{testRuns.length}</span>
+                                    <span className="stat-value">{totalTestRuns ?? 0}</span>
                                     <span className="stat-label">Total Runs</span>
                                 </div>
                                 <div className="stat-item">
-                                    <span className="stat-value">{recentRuns}</span>
+                                    <span className="stat-value">{recentTestRuns ?? 0}</span>
                                     <span className="stat-label">Recent Runs</span>
                                 </div>
                             </div>
@@ -8737,7 +8732,7 @@
         // Main App component
         function FernPlatform() {
             const { route, navigate } = useRouter();
-            const [appData, setAppData] = useState({ health: null, projects: [], testRuns: [] });
+            const [appData, setAppData] = useState({ health: null, projects: [], totalTestRuns: 0, recentTestRuns: 0 });
             const [showSettings, setShowSettings] = useState(false);
 
             useEffect(() => {
@@ -8759,7 +8754,8 @@
                     setAppData({
                         health: summaryData.dashboardSummary.health,
                         projects: projectList,
-                        testRuns: [] // Pages will load their own test runs as needed
+                        totalTestRuns: summaryData.dashboardSummary.totalTestRuns ?? 0,
+                        recentTestRuns: summaryData.dashboardSummary.recentTestRuns ?? 0
                     });
                 } catch (err) {
                     console.error('Failed to fetch app data:', err);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect dashboard totals by counting all test runs in the database and 24h recent runs, instead of inferring from a limited recent list. The backend now returns accurate `totalTestRuns` and `recentTestRuns`, and the web header displays them.

- **Bug Fixes**
  - Added `CountAll` and `CountSince` to `TestRunRepository` with `GormTestRunRepository` implementations (24h window).
  - Exposed `CountAllTestRuns` and `CountTestRunsSince` in `TestRunService`.
  - Updated GraphQL `DashboardSummary_domain` to use these counts for `totalTestRuns` and `recentTestRuns`.
  - Updated web header to consume these fields and removed client-side recent run calculation.
  - Adjusted mocks and tests to cover the new repository methods.

<sup>Written for commit 80032570babb7e742c1499288c7adce34fa432f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

