### PR TITLE
fix(ci): bump go version to 1.25 in ci job for govulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
     
     - name: Run govulncheck
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: 1.25 # govulncheck requires Go version >=1.25
     
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
 # and add it as a secret named 'GH_PAT'
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   DAGGER_VERSION: '0.18.14'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
 # and add it as a secret named 'GH_PAT'
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   DAGGER_VERSION: '0.18.14'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -121,7 +121,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25 # govulncheck requires Go version >=1.25
+        go-version: ${{ env.GO_VERSION }}
     
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
The latest `govulncheck` version (v1.2.0) requires Go ≥ `1.25`. 
Bumped up Go version to `1.25` only for the `Go Vulnerability Check` CI job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump CI Go to 1.26 and pin `govulncheck` to v1.3.0 to meet its minimum Go requirement and keep vulnerability checks stable.

<sup>Written for commit 0bee4da3caa3bde4f0d6f19365ee0b9a72022b95. Summary will update on new commits. <a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/176?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

