### PR TITLE
fix: scope non-admin test run queries to team-accessible projects (#184)

### DIFF
--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -148,6 +148,10 @@ func (m *MockTestRunRepository) GetDashboardStats(ctx context.Context) (*domain.
 	return args.Get(0).(*domain.DashboardStatsResult), args.Error(1)
 }
 
+func (m *MockTestRunRepository) GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*domain.TestRun, int64, error) {
+	return nil, 0, nil
+}
+
 // MockSuiteRunRepository provides a mock implementation of SuiteRunRepository
 type MockSuiteRunRepository struct {
 	mock.Mock

--- a/internal/domains/testing/application/complete_test_run_test.go
+++ b/internal/domains/testing/application/complete_test_run_test.go
@@ -50,6 +50,9 @@ func (m *mockTestRunRepo) GetByRunID(ctx context.Context, runID string) (*domain
 func (m *mockTestRunRepo) FindByDateRangeForProjects(ctx context.Context, projectIDs []string, startDate, endDate time.Time) ([]*domain.TestRun, error) {
 	return nil, nil
 }
+func (m *mockTestRunRepo) GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*domain.TestRun, int64, error) {
+	return nil, 0, nil
+}
 func (m *mockTestRunRepo) Update(ctx context.Context, tr *domain.TestRun) error {
 	args := m.Called(ctx, tr)
 	return args.Error(0)

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -332,6 +332,10 @@ func (s *TestRunService) GetRecentTestRuns(ctx context.Context, limit int) ([]*d
 	return s.testRunRepo.GetRecent(ctx, limit)
 }
 
+func (s *TestRunService) GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*domain.TestRun, int64, error) {
+	return s.testRunRepo.GetRecentByProjectIDs(ctx, projectIDs, limit, offset)
+}
+
 // GetDashboardStats returns platform-wide aggregate stats.
 func (s *TestRunService) GetDashboardStats(ctx context.Context) (*domain.DashboardStatsResult, error) {
 	return s.testRunRepo.GetDashboardStats(ctx)

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -180,6 +180,10 @@ func (m *MockTestRunRepository) GetDashboardStats(ctx context.Context) (*domain.
 	return args.Get(0).(*domain.DashboardStatsResult), args.Error(1)
 }
 
+func (m *MockTestRunRepository) GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*domain.TestRun, int64, error) {
+	return nil, 0, nil
+}
+
 // Mock suite run repository
 type MockSuiteRunRepository struct {
 	mock.Mock

--- a/internal/domains/testing/domain/repository.go
+++ b/internal/domains/testing/domain/repository.go
@@ -53,6 +53,11 @@ type TestRunRepository interface {
 	// GetRecent retrieves recent test runs across all projects
 	GetRecent(ctx context.Context, limit int) ([]*TestRun, error)
 
+	// GetRecentByProjectIDs fetches recent test runs across a set of projects in one batched
+	// query, sorted globally by start_time DESC. Tags only — no SuiteRuns/SpecRuns preloaded.
+	// Returns the page of runs and the total count across all supplied projects.
+	GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*TestRun, int64, error)
+
 	// GetDashboardStats returns platform-wide aggregate stats in a single query.
 	GetDashboardStats(ctx context.Context) (*DashboardStatsResult, error)
 }

--- a/internal/domains/testing/infrastructure/gorm_test_run_repo.go
+++ b/internal/domains/testing/infrastructure/gorm_test_run_repo.go
@@ -251,6 +251,37 @@ func (r *GormTestRunRepository) FindByDateRangeForProjects(ctx context.Context, 
 	return testRuns, nil
 }
 
+// GetRecentByProjectIDs fetches recent test runs across a set of projects in one batched
+// query sorted globally by start_time DESC. Tags only — no SuiteRuns/SpecRuns preloaded.
+func (r *GormTestRunRepository) GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*domain.TestRun, int64, error) {
+	if len(projectIDs) == 0 {
+		return nil, 0, nil
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var total int64
+	if err := r.db.WithContext(ctx).Model(&database.TestRun{}).
+		Where("project_id IN ?", projectIDs).
+		Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count test runs by project IDs: %w", err)
+	}
+	var dbTestRuns []database.TestRun
+	if err := r.db.WithContext(ctx).
+		Where("project_id IN ?", projectIDs).
+		Preload("Tags").
+		Order("start_time DESC").
+		Limit(limit).Offset(offset).
+		Find(&dbTestRuns).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to find recent test runs by project IDs: %w", err)
+	}
+	runs := make([]*domain.TestRun, len(dbTestRuns))
+	for i, dbRun := range dbTestRuns {
+		runs[i] = r.converter.ConvertTestRunToDomain(&dbRun)
+	}
+	return runs, total, nil
+}
+
 // GetTestRunSummary retrieves summary statistics for a project
 func (r *GormTestRunRepository) GetTestRunSummary(ctx context.Context, projectID string) (*domain.TestRunSummary, error) {
 	var summary domain.TestRunSummary

--- a/internal/reporter/graphql/domain_resolvers.go
+++ b/internal/reporter/graphql/domain_resolvers.go
@@ -32,10 +32,15 @@ func userCanAccessProject(snapshot projectsDomain.ProjectSnapshot, teamMap map[s
 }
 
 // getAccessibleProjectSnapshots returns snapshots for all projects the calling user's teams can access.
+// TODO(P1-4): replace with projects/application.ListAccessibleProjects + projects/repository.FindByTeams
+// to push filtering into the DB and remove the silent 1000-project access-loss bug.
 func (r *Resolver) getAccessibleProjectSnapshots(ctx context.Context) ([]projectsDomain.ProjectSnapshot, error) {
 	projects, _, err := r.projectService.ListProjects(ctx, 1000, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
+	if len(projects) == 1000 {
+		r.logger.Warn("getAccessibleProjectSnapshots: reached 1000-project cap; some projects may be excluded from non-admin views")
 	}
 	teamMap := buildTeamMap(getUserTeamsFromContext(ctx))
 	snapshots := make([]projectsDomain.ProjectSnapshot, 0, len(projects))
@@ -46,6 +51,15 @@ func (r *Resolver) getAccessibleProjectSnapshots(ctx context.Context) ([]project
 		}
 	}
 	return snapshots, nil
+}
+
+// snapshotsToProjectIDs extracts project ID strings from a snapshot slice.
+func snapshotsToProjectIDs(snapshots []projectsDomain.ProjectSnapshot) []string {
+	ids := make([]string, len(snapshots))
+	for i, snap := range snapshots {
+		ids[i] = string(snap.ProjectID)
+	}
+	return ids
 }
 
 // buildTestRunConnection assembles a paginated TestRunConnection from a pre-sliced run list.
@@ -253,13 +267,16 @@ func (r *queryResolver) RecentTestRuns_domain(ctx context.Context, projectID *st
 		limitVal = *limit
 	}
 
+	user, userErr := getCurrentUser(ctx)
+	if userErr != nil {
+		return nil, fmt.Errorf("user not authenticated")
+	}
+
 	var testRuns []*testingDomain.TestRun
 	var err error
 
-	user, userErr := getCurrentUser(ctx)
 	if projectID != nil {
-		// For non-admins, verify the user belongs to the project's team before returning runs.
-		if userErr == nil && user.Role != authDomain.RoleAdmin {
+		if user.Role != authDomain.RoleAdmin {
 			project, projErr := r.projectService.GetProject(ctx, projectsDomain.ProjectID(*projectID))
 			if projErr != nil || project == nil {
 				return nil, fmt.Errorf("project not found")
@@ -271,27 +288,14 @@ func (r *queryResolver) RecentTestRuns_domain(ctx context.Context, projectID *st
 			}
 		}
 		testRuns, err = r.testingService.GetProjectTestRuns(ctx, *projectID, limitVal)
+	} else if user.Role != authDomain.RoleAdmin {
+		snapshots, projErr := r.getAccessibleProjectSnapshots(ctx)
+		if projErr != nil {
+			return nil, projErr
+		}
+		testRuns, _, err = r.testingService.GetRecentByProjectIDs(ctx, snapshotsToProjectIDs(snapshots), limitVal, 0)
 	} else {
-		// Cross-project query — admins see all runs; non-admins see runs scoped to their teams.
-		if userErr != nil {
-			return nil, fmt.Errorf("user not authenticated")
-		}
-		if user.Role != authDomain.RoleAdmin {
-			snapshots, projErr := r.getAccessibleProjectSnapshots(ctx)
-			if projErr != nil {
-				return nil, projErr
-			}
-			// TODO: replace per-project loop with GetRecentTestRunsByProjectIDs(ctx, projectIDs, limitVal)
-			// to eliminate the N+1 query pattern.
-			for _, snap := range snapshots {
-				runs, runErr := r.testingService.GetProjectTestRuns(ctx, string(snap.ProjectID), limitVal)
-				if runErr == nil {
-					testRuns = append(testRuns, runs...)
-				}
-			}
-		} else {
-			testRuns, err = r.testingService.GetRecentTestRuns(ctx, limitVal)
-		}
+		testRuns, err = r.testingService.GetRecentTestRuns(ctx, limitVal)
 	}
 
 	if err != nil {
@@ -1244,6 +1248,9 @@ func (r *queryResolver) TestRuns_domain(ctx context.Context, filter *model.TestR
 			offset = idx + 1
 		}
 	}
+	if offset > 10000 {
+		offset = 10000
+	}
 
 	// Get project ID from filter if provided
 	projectID := ""
@@ -1254,31 +1261,16 @@ func (r *queryResolver) TestRuns_domain(ctx context.Context, filter *model.TestR
 	// Enforce team-based authorization for non-admin users.
 	if user.Role != authDomain.RoleAdmin {
 		if projectID == "" {
-			// No projectId — collect all accessible runs then paginate globally.
+			// No projectId — fetch globally sorted runs across all accessible projects in one query.
 			snapshots, projErr := r.getAccessibleProjectSnapshots(ctx)
 			if projErr != nil {
 				return nil, projErr
 			}
-			var allRuns []*testingDomain.TestRun
-			var totalCount int64
-			// TODO: replace per-project loop with a single GetRecentTestRunsByProjectIDs(ctx, projectIDs, pageSize, offset)
-			// call to eliminate the N+1 query pattern and give correct cross-project pagination.
-			perProjectLimit := pageSize + offset
-			for _, snap := range snapshots {
-				runs, count, runErr := r.testingService.ListTestRuns(ctx, string(snap.ProjectID), perProjectLimit, 0)
-				if runErr == nil {
-					allRuns = append(allRuns, runs...)
-					totalCount += count
-				}
+			runs, totalCount, runErr := r.testingService.GetRecentByProjectIDs(ctx, snapshotsToProjectIDs(snapshots), pageSize, offset)
+			if runErr != nil {
+				return nil, fmt.Errorf("failed to list test runs: %w", runErr)
 			}
-			start, end := offset, offset+pageSize
-			if start > len(allRuns) {
-				start = len(allRuns)
-			}
-			if end > len(allRuns) {
-				end = len(allRuns)
-			}
-			return r.buildTestRunConnection(allRuns[start:end], offset, totalCount), nil
+			return r.buildTestRunConnection(runs, offset, totalCount), nil
 		}
 		project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(projectID))
 		if err != nil || project == nil {

--- a/internal/reporter/graphql/domain_resolvers.go
+++ b/internal/reporter/graphql/domain_resolvers.go
@@ -31,6 +31,48 @@ func userCanAccessProject(snapshot projectsDomain.ProjectSnapshot, teamMap map[s
 	return snapshot.Team != "" && teamMap[string(snapshot.Team)]
 }
 
+// getAccessibleProjectSnapshots returns snapshots for all projects the calling user's teams can access.
+func (r *Resolver) getAccessibleProjectSnapshots(ctx context.Context) ([]projectsDomain.ProjectSnapshot, error) {
+	projects, _, err := r.projectService.ListProjects(ctx, 1000, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list projects: %w", err)
+	}
+	teamMap := buildTeamMap(getUserTeamsFromContext(ctx))
+	snapshots := make([]projectsDomain.ProjectSnapshot, 0, len(projects))
+	for _, p := range projects {
+		snap := p.ToSnapshot()
+		if userCanAccessProject(snap, teamMap) {
+			snapshots = append(snapshots, snap)
+		}
+	}
+	return snapshots, nil
+}
+
+// buildTestRunConnection assembles a paginated TestRunConnection from a pre-sliced run list.
+func (r *Resolver) buildTestRunConnection(runs []*testingDomain.TestRun, offset int, totalCount int64) *model.TestRunConnection {
+	edges := make([]*model.TestRunEdge, len(runs))
+	for i, run := range runs {
+		cursor := fmt.Sprintf("%d", offset+i)
+		edges[i] = &model.TestRunEdge{
+			Node:   r.convertTestRunToGraphQL(run),
+			Cursor: cursor,
+		}
+	}
+	pageInfo := &model.PageInfo{
+		HasNextPage:     offset+len(runs) < int(totalCount),
+		HasPreviousPage: offset > 0,
+	}
+	if len(edges) > 0 {
+		pageInfo.StartCursor = &edges[0].Cursor
+		pageInfo.EndCursor = &edges[len(edges)-1].Cursor
+	}
+	return &model.TestRunConnection{
+		Edges:      edges,
+		PageInfo:   pageInfo,
+		TotalCount: int(totalCount),
+	}
+}
+
 // convertTestRunToGraphQL converts a domain test run to GraphQL model
 func (r *Resolver) convertTestRunToGraphQL(testRun *testingDomain.TestRun) *model.TestRun {
 	return r.ConvertTestRunToGraphQL(testRun)
@@ -230,11 +272,26 @@ func (r *queryResolver) RecentTestRuns_domain(ctx context.Context, projectID *st
 		}
 		testRuns, err = r.testingService.GetProjectTestRuns(ctx, *projectID, limitVal)
 	} else {
-		// Cross-project query — admins see all runs; non-admins get an access error.
-		if userErr != nil || user.Role != authDomain.RoleAdmin {
-			return nil, fmt.Errorf("access denied: projectId is required for non-admin users")
+		// Cross-project query — admins see all runs; non-admins see runs scoped to their teams.
+		if userErr != nil {
+			return nil, fmt.Errorf("user not authenticated")
 		}
-		testRuns, err = r.testingService.GetRecentTestRuns(ctx, limitVal)
+		if user.Role != authDomain.RoleAdmin {
+			snapshots, projErr := r.getAccessibleProjectSnapshots(ctx)
+			if projErr != nil {
+				return nil, projErr
+			}
+			// TODO: replace per-project loop with GetRecentTestRunsByProjectIDs(ctx, projectIDs, limitVal)
+			// to eliminate the N+1 query pattern.
+			for _, snap := range snapshots {
+				runs, runErr := r.testingService.GetProjectTestRuns(ctx, string(snap.ProjectID), limitVal)
+				if runErr == nil {
+					testRuns = append(testRuns, runs...)
+				}
+			}
+		} else {
+			testRuns, err = r.testingService.GetRecentTestRuns(ctx, limitVal)
+		}
 	}
 
 	if err != nil {
@@ -1197,8 +1254,31 @@ func (r *queryResolver) TestRuns_domain(ctx context.Context, filter *model.TestR
 	// Enforce team-based authorization for non-admin users.
 	if user.Role != authDomain.RoleAdmin {
 		if projectID == "" {
-			// No projectId and non-admin: return error rather than silently hiding all runs.
-			return nil, fmt.Errorf("access denied: projectId is required for non-admin users")
+			// No projectId — collect all accessible runs then paginate globally.
+			snapshots, projErr := r.getAccessibleProjectSnapshots(ctx)
+			if projErr != nil {
+				return nil, projErr
+			}
+			var allRuns []*testingDomain.TestRun
+			var totalCount int64
+			// TODO: replace per-project loop with a single GetRecentTestRunsByProjectIDs(ctx, projectIDs, pageSize, offset)
+			// call to eliminate the N+1 query pattern and give correct cross-project pagination.
+			perProjectLimit := pageSize + offset
+			for _, snap := range snapshots {
+				runs, count, runErr := r.testingService.ListTestRuns(ctx, string(snap.ProjectID), perProjectLimit, 0)
+				if runErr == nil {
+					allRuns = append(allRuns, runs...)
+					totalCount += count
+				}
+			}
+			start, end := offset, offset+pageSize
+			if start > len(allRuns) {
+				start = len(allRuns)
+			}
+			if end > len(allRuns) {
+				end = len(allRuns)
+			}
+			return r.buildTestRunConnection(allRuns[start:end], offset, totalCount), nil
 		}
 		project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(projectID))
 		if err != nil || project == nil {
@@ -1211,38 +1291,11 @@ func (r *queryResolver) TestRuns_domain(ctx context.Context, filter *model.TestR
 		}
 	}
 
-	// Get test runs with pagination
 	testRuns, totalCount, err := r.testingService.ListTestRuns(ctx, projectID, pageSize, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list test runs: %w", err)
 	}
-
-	hasMore := offset+len(testRuns) < int(totalCount)
-
-	// Build edges
-	edges := make([]*model.TestRunEdge, len(testRuns))
-	for i, run := range testRuns {
-		edges[i] = &model.TestRunEdge{
-			Node:   r.convertTestRunToGraphQL(run),
-			Cursor: fmt.Sprintf("%d", offset+i), // Simple cursor
-		}
-	}
-
-	// Build page info
-	pageInfo := &model.PageInfo{
-		HasNextPage:     hasMore,
-		HasPreviousPage: offset > 0,
-	}
-	if len(edges) > 0 {
-		pageInfo.StartCursor = &edges[0].Cursor
-		pageInfo.EndCursor = &edges[len(edges)-1].Cursor
-	}
-
-	return &model.TestRunConnection{
-		Edges:      edges,
-		PageInfo:   pageInfo,
-		TotalCount: int(totalCount),
-	}, nil
+	return r.buildTestRunConnection(testRuns, offset, totalCount), nil
 }
 
 // Tags implementation using domain service with pagination

--- a/internal/reporter/graphql/domain_resolvers_ginkgo_test.go
+++ b/internal/reporter/graphql/domain_resolvers_ginkgo_test.go
@@ -184,7 +184,7 @@ var _ = Describe("DomainResolvers", func() {
 
 				mockRepo.On("GetLatestByProjectIDTagsOnly", mock.Anything, projectID, 10).Return(testRuns, nil)
 
-				result, err := resolver.Query().(*queryResolver).RecentTestRuns_domain(ctx, &projectID, nil)
+				result, err := resolver.Query().(*queryResolver).RecentTestRuns_domain(adminCtx, &projectID, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(HaveLen(1))

--- a/internal/reporter/graphql/domain_resolvers_integration_test.go
+++ b/internal/reporter/graphql/domain_resolvers_integration_test.go
@@ -236,7 +236,7 @@ Expect(err).To(BeNil())
 }
 
 projectID := "project-a"
-result, err := qr.RecentTestRuns_domain(ctx, &projectID, nil)
+result, err := qr.RecentTestRuns_domain(adminCtx, &projectID, nil)
 Expect(err).To(BeNil())
 Expect(result).NotTo(BeNil())
 Expect(len(result)).To(Equal(2))

--- a/internal/reporter/graphql/domain_resolvers_test.go
+++ b/internal/reporter/graphql/domain_resolvers_test.go
@@ -1259,15 +1259,44 @@ func TestAuthorizationNegativeCases(t *testing.T) {
 		Groups: []authDomain.UserGroup{{GroupName: "team-a"}},
 	})
 
-	t.Run("RecentTestRuns_domain: non-admin without projectId gets access denied", func(t *testing.T) {
-		resolver := NewResolver(nil, nil, nil, nil, nil, db, logger)
+	t.Run("RecentTestRuns_domain: non-admin without projectId gets runs scoped to their teams", func(t *testing.T) {
+		mockRunRepo := new(testhelpers.MockTestRunRepository)
+		mockProjRepo := new(testhelpers.MockProjectRepository)
+		mockPermRepo := new(testhelpers.MockProjectPermissionRepository)
+
+		teamAProject, _ := projectsDomain.NewProject(
+			projectsDomain.ProjectID("proj-team-a"),
+			"Team A Project",
+			projectsDomain.Team("team-a"),
+		)
+		teamBProject, _ := projectsDomain.NewProject(
+			projectsDomain.ProjectID("proj-team-b"),
+			"Team B Project",
+			projectsDomain.Team("team-b"),
+		)
+		mockProjRepo.On("FindAll", mock.Anything, 1000, 0).Return(
+			[]*projectsDomain.Project{teamAProject, teamBProject}, int64(2), nil,
+		)
+
+		teamARuns := []*testingDomain.TestRun{
+			{ID: 1, RunID: "run-1", ProjectID: "proj-team-a", Status: "completed", Tags: []testingDomain.Tag{}, SuiteRuns: []testingDomain.SuiteRun{}},
+		}
+		mockRunRepo.On("GetLatestByProjectIDTagsOnly", mock.Anything, "proj-team-a", 10).Return(teamARuns, nil)
+
+		testingService := testingApp.NewTestRunService(mockRunRepo, nil, nil)
+		projectService := projectsApp.NewProjectService(mockProjRepo, mockPermRepo)
+
+		resolver := NewResolver(testingService, projectService, nil, nil, nil, db, logger)
 		queryResolver := &queryResolver{resolver}
 
 		result, err := queryResolver.RecentTestRuns_domain(nonAdminCtx, nil, nil)
 
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "access denied")
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "run-1", result[0].RunID)
+		mockRunRepo.AssertExpectations(t)
+		mockProjRepo.AssertExpectations(t)
 	})
 
 	t.Run("RecentTestRuns_domain: unauthenticated request returns empty (admin-required check)", func(t *testing.T) {
@@ -1840,6 +1869,57 @@ func TestTreemapData_domain(t *testing.T) {
 func TestTestRuns_domain(t *testing.T) {
 	t.Run("with pagination", func(t *testing.T) {
 		t.Skip("Requires service setup with mocked repositories")
+	})
+
+	t.Run("non-admin without projectId gets runs scoped to their teams", func(t *testing.T) {
+		logger, _ := logging.NewLogger(&config.LoggingConfig{Level: "error", Format: "json", Output: "stdout", Structured: true})
+		db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+
+		nonAdminCtx := context.WithValue(context.Background(), "user", &authDomain.User{
+			UserID: "user1",
+			Role:   authDomain.RoleUser,
+			Groups: []authDomain.UserGroup{{GroupName: "team-a"}},
+		})
+
+		mockRunRepo := new(testhelpers.MockTestRunRepository)
+		mockProjRepo := new(testhelpers.MockProjectRepository)
+		mockPermRepo := new(testhelpers.MockProjectPermissionRepository)
+
+		teamAProject, _ := projectsDomain.NewProject(
+			projectsDomain.ProjectID("proj-team-a"),
+			"Team A Project",
+			projectsDomain.Team("team-a"),
+		)
+		teamBProject, _ := projectsDomain.NewProject(
+			projectsDomain.ProjectID("proj-team-b"),
+			"Team B Project",
+			projectsDomain.Team("team-b"),
+		)
+		mockProjRepo.On("FindAll", mock.Anything, 1000, 0).Return(
+			[]*projectsDomain.Project{teamAProject, teamBProject}, int64(2), nil,
+		)
+
+		teamARuns := []*testingDomain.TestRun{
+			{ID: 1, RunID: "run-1", ProjectID: "proj-team-a", Status: "completed", Tags: []testingDomain.Tag{}, SuiteRuns: []testingDomain.SuiteRun{}},
+		}
+		mockRunRepo.On("GetLatestByProjectID", mock.Anything, "proj-team-a", mock.AnythingOfType("int")).Return(teamARuns, nil)
+		mockRunRepo.On("CountByProjectID", mock.Anything, "proj-team-a").Return(int64(1), nil)
+
+		testingService := testingApp.NewTestRunService(mockRunRepo, nil, nil)
+		projectService := projectsApp.NewProjectService(mockProjRepo, mockPermRepo)
+
+		resolver := NewResolver(testingService, projectService, nil, nil, nil, db, logger)
+		queryResolver := &queryResolver{resolver}
+
+		result, err := queryResolver.TestRuns_domain(nonAdminCtx, nil, nil, nil, nil, nil)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.Edges)
+		assert.Len(t, result.Edges, 1)
+		assert.Equal(t, "run-1", result.Edges[0].Node.RunID)
+		mockRunRepo.AssertExpectations(t)
+		mockProjRepo.AssertExpectations(t)
 	})
 }
 

--- a/internal/reporter/graphql/domain_resolvers_test.go
+++ b/internal/reporter/graphql/domain_resolvers_test.go
@@ -1281,7 +1281,7 @@ func TestAuthorizationNegativeCases(t *testing.T) {
 		teamARuns := []*testingDomain.TestRun{
 			{ID: 1, RunID: "run-1", ProjectID: "proj-team-a", Status: "completed", Tags: []testingDomain.Tag{}, SuiteRuns: []testingDomain.SuiteRun{}},
 		}
-		mockRunRepo.On("GetLatestByProjectIDTagsOnly", mock.Anything, "proj-team-a", 10).Return(teamARuns, nil)
+		mockRunRepo.On("GetRecentByProjectIDs", mock.Anything, []string{"proj-team-a"}, 10, 0).Return(teamARuns, int64(1), nil)
 
 		testingService := testingApp.NewTestRunService(mockRunRepo, nil, nil)
 		projectService := projectsApp.NewProjectService(mockProjRepo, mockPermRepo)
@@ -1467,7 +1467,13 @@ func TestRecentTestRuns_domain(t *testing.T) {
 		resolver := NewResolver(testingService, nil, nil, nil, nil, db, logger)
 		queryResolver := &queryResolver{resolver}
 
-		result, err := queryResolver.RecentTestRuns_domain(context.Background(), &projectID, nil)
+		// Admin context: bypasses the per-project team check (no project service mock needed).
+		adminCtx := context.WithValue(context.Background(), "user", &authDomain.User{
+			UserID:  "admin-1",
+			Role:    authDomain.RoleAdmin,
+			Groups:  []authDomain.UserGroup{},
+		})
+		result, err := queryResolver.RecentTestRuns_domain(adminCtx, &projectID, nil)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -1562,7 +1568,12 @@ func TestRecentTestRuns_domain(t *testing.T) {
 		resolver := NewResolver(testingService, nil, nil, nil, nil, db, logger)
 		queryResolver := &queryResolver{resolver}
 
-		result, err := queryResolver.RecentTestRuns_domain(context.Background(), &projectID, &limit)
+		adminCtx := context.WithValue(context.Background(), "user", &authDomain.User{
+			UserID:  "admin",
+			Role:    authDomain.RoleAdmin,
+			Groups:  []authDomain.UserGroup{},
+		})
+		result, err := queryResolver.RecentTestRuns_domain(adminCtx, &projectID, &limit)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
@@ -1902,8 +1913,7 @@ func TestTestRuns_domain(t *testing.T) {
 		teamARuns := []*testingDomain.TestRun{
 			{ID: 1, RunID: "run-1", ProjectID: "proj-team-a", Status: "completed", Tags: []testingDomain.Tag{}, SuiteRuns: []testingDomain.SuiteRun{}},
 		}
-		mockRunRepo.On("GetLatestByProjectID", mock.Anything, "proj-team-a", mock.AnythingOfType("int")).Return(teamARuns, nil)
-		mockRunRepo.On("CountByProjectID", mock.Anything, "proj-team-a").Return(int64(1), nil)
+		mockRunRepo.On("GetRecentByProjectIDs", mock.Anything, []string{"proj-team-a"}, 20, 0).Return(teamARuns, int64(1), nil)
 
 		testingService := testingApp.NewTestRunService(mockRunRepo, nil, nil)
 		projectService := projectsApp.NewProjectService(mockProjRepo, mockPermRepo)

--- a/internal/testhelpers/mocks.go
+++ b/internal/testhelpers/mocks.go
@@ -312,6 +312,14 @@ func (m *MockTestRunRepository) GetDashboardStats(ctx context.Context) (*testing
 	return args.Get(0).(*testingDomain.DashboardStatsResult), args.Error(1)
 }
 
+func (m *MockTestRunRepository) GetRecentByProjectIDs(ctx context.Context, projectIDs []string, limit, offset int) ([]*testingDomain.TestRun, int64, error) {
+	args := m.Called(ctx, projectIDs, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*testingDomain.TestRun), args.Get(1).(int64), args.Error(2)
+}
+
 func (m *MockTestRunRepository) Create(ctx context.Context, testRun *testingDomain.TestRun) error {
 	args := m.Called(ctx, testRun)
 	return args.Error(0)


### PR DESCRIPTION
fix: scope non-admin test run queries to accessible projects (#184)

  Non-admin users were receiving "access denied: projectId is required"
  on the dashboard, test runs, and test summaries pages when no projectId
  filter was set. Instead of erroring, non-admins now see runs scoped to
  projects their teams can access, matching the existing behaviour of
  ListProjects_domain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-admin test run queries so they return runs from team-accessible projects when no projectId is given, instead of “access denied.” Adds a batched, globally sorted query path and shared pagination to restore dashboard, test runs, and summaries with correct team scoping.

- **Bug Fixes**
  - Scoped cross-project queries for non-admins in `RecentTestRuns_domain` and `TestRuns_domain`; admins unchanged; unauthenticated requests return an auth error.
  - Added `GetRecentByProjectIDs` in the repository/service with a GORM implementation; fetches recent runs (tags only) across accessible projects in one query and returns runs plus `totalCount`.
  - Added `getAccessibleProjectSnapshots` and `snapshotsToProjectIDs` to derive team-accessible project IDs; warns on a 1000-project cap and notes a follow-up to push filtering into the DB.
  - Centralized GraphQL pagination via `buildTestRunConnection` and capped offset at 10k; updated tests for scoped behavior and admin-context checks.

<sup>Written for commit 90b100ce04a30f3fe9891d972511a71acb582a22. Summary will update on new commits. <a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

