### PR TITLE
fix: load JIRA integration key from environment configuration (#186)

### DIFF
--- a/internal/domains/factory.go
+++ b/internal/domains/factory.go
@@ -1,6 +1,10 @@
 package domains
 
 import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
 	"gorm.io/gorm"
 
 	// Auth domain
@@ -258,9 +262,17 @@ func (f *DomainFactory) initIntegrationsDomain() {
 	// Create JIRA client
 	jiraClient := integrations.NewDefaultJiraClient()
 
-	// Get encryption key from config (or generate one)
-	// For now, use a placeholder - in production this should come from secure config
-	encryptionKey := []byte("your-32-byte-encryption-key-here") // TODO: Load from secure config
+	keyHex := os.Getenv("JIRA_ENCRYPTION_KEY")
+	if keyHex == "" {
+		panic("JIRA_ENCRYPTION_KEY environment variable is not set; generate with: openssl rand -hex 32")
+	}
+	encryptionKey, err := hex.DecodeString(keyHex)
+	if err != nil {
+		panic(fmt.Sprintf("JIRA_ENCRYPTION_KEY is not valid hex: %v", err))
+	}
+	if len(encryptionKey) != 32 {
+		panic(fmt.Sprintf("JIRA_ENCRYPTION_KEY must decode to exactly 32 bytes, got %d", len(encryptionKey)))
+	}
 
 	// Create service
 	f.jiraConnectionService = integrations.NewJiraConnectionService(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load the JIRA integration encryption key from the `JIRA_ENCRYPTION_KEY` env var and validate it, replacing the hardcoded placeholder. The app now fails fast on startup if the key is missing, not hex, or not exactly 32 bytes.

- **Migration**
  - Set `JIRA_ENCRYPTION_KEY` to a 64-char hex string (32 bytes), e.g., `openssl rand -hex 32`.
  - Restart the service.

<sup>Written for commit 0c7581ccf02a1606289ef61c83c27b98d00617b7. Summary will update on new commits. <a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

