### PR TITLE
fix(auth): admin bypass and write-level permission checks for JIRA connections -- #192

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -53,7 +53,7 @@ func (h *AuthHandler) getCurrentUser(c *gin.Context) {
 	userID := h.getUserID(c)
 	userName, _ := c.Get("user_name")
 	userEmail, _ := c.Get("user_email")
-	userRole, _ := c.Get("role")
+	userRole, _ := c.Get("user_role")
 	teamID, _ := c.Get("team_id")
 	teamName, _ := c.Get("team_name")
 

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -19,7 +19,7 @@ func authContextMiddleware(userID, userName, userEmail, role, teamID, teamName s
 		c.Set("user_id", userID)
 		c.Set("user_name", userName)
 		c.Set("user_email", userEmail)
-		c.Set("role", role)
+		c.Set("user_role", role)
 		c.Set("team_id", teamID)
 		c.Set("team_name", teamName)
 		c.Next()

--- a/internal/api/base_handler.go
+++ b/internal/api/base_handler.go
@@ -30,20 +30,32 @@ func (h *BaseHandler) respondWithJSON(c *gin.Context, code int, payload interfac
 
 // getUserID extracts the user ID from the context
 func (h *BaseHandler) getUserID(c *gin.Context) string {
-	userID, _ := c.Get("user_id")
-	return userID.(string)
+	userID, ok := c.Get("user_id")
+	if !ok || userID == nil {
+		return ""
+	}
+	s, _ := userID.(string)
+	return s
 }
 
 // getTeamID extracts the team ID from the context
 func (h *BaseHandler) getTeamID(c *gin.Context) string {
-	teamID, _ := c.Get("team_id")
-	return teamID.(string)
+	teamID, ok := c.Get("team_id")
+	if !ok || teamID == nil {
+		return ""
+	}
+	s, _ := teamID.(string)
+	return s
 }
 
 // getUserRole extracts the user role from the context
 func (h *BaseHandler) getUserRole(c *gin.Context) string {
-	role, _ := c.Get("role")
-	return role.(string)
+	role, ok := c.Get("role")
+	if !ok || role == nil {
+		return ""
+	}
+	s, _ := role.(string)
+	return s
 }
 
 // isAdmin checks if the user has admin role
@@ -59,8 +71,12 @@ func (h *BaseHandler) isManager(c *gin.Context) bool {
 
 // getUserEmail extracts the user email from the context
 func (h *BaseHandler) getUserEmail(c *gin.Context) string {
-	email, _ := c.Get("user_email")
-	return email.(string)
+	email, ok := c.Get("user_email")
+	if !ok || email == nil {
+		return ""
+	}
+	s, _ := email.(string)
+	return s
 }
 
 // ErrorResponse sends an error response with the given status code and message

--- a/internal/api/base_handler.go
+++ b/internal/api/base_handler.go
@@ -50,7 +50,7 @@ func (h *BaseHandler) getTeamID(c *gin.Context) string {
 
 // getUserRole extracts the user role from the context
 func (h *BaseHandler) getUserRole(c *gin.Context) string {
-	role, ok := c.Get("role")
+	role, ok := c.Get("user_role")
 	if !ok || role == nil {
 		return ""
 	}

--- a/internal/api/jira_connection_handler.go
+++ b/internal/api/jira_connection_handler.go
@@ -115,19 +115,19 @@ func (h *JiraConnectionHandler) CreateConnection(c *gin.Context) {
 		return
 	}
 
-	// Check project permissions
-	permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(projectID), userID)
-	if err != nil {
-		h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
-		return
-	}
-
 	// Check if user has write permission (needed to manage connections)
-	canManage := false
-	for _, perm := range permissions {
-		if perm.CanWrite() || perm.CanAdmin() {
-			canManage = true
-			break
+	canManage := h.isAdmin(c)
+	if !canManage {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(projectID), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanWrite() || perm.CanAdmin() {
+				canManage = true
+				break
+			}
 		}
 	}
 
@@ -177,6 +177,25 @@ func (h *JiraConnectionHandler) GetConnections(c *gin.Context) {
 		return
 	}
 
+	canView := h.isAdmin(c)
+	if !canView {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(projectID), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanRead() {
+				canView = true
+				break
+			}
+		}
+	}
+	if !canView {
+		h.ErrorResponse(c, http.StatusForbidden, "forbidden")
+		return
+	}
+
 	connections, err := h.jiraService.GetProjectConnections(c.Request.Context(), projectID)
 	if err != nil {
 		h.ErrorResponse(c, http.StatusInternalServerError, err.Error())
@@ -208,19 +227,19 @@ func (h *JiraConnectionHandler) GetConnection(c *gin.Context) {
 		return
 	}
 
-	// Check project permissions
-	permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
-	if err != nil {
-		h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
-		return
-	}
-
 	// Check if user has read permission
-	canView := false
-	for _, perm := range permissions {
-		if perm.CanRead() {
-			canView = true
-			break
+	canView := h.isAdmin(c)
+	if !canView {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanRead() {
+				canView = true
+				break
+			}
 		}
 	}
 
@@ -249,19 +268,19 @@ func (h *JiraConnectionHandler) UpdateConnection(c *gin.Context) {
 		return
 	}
 
-	// Check project permissions
-	permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
-	if err != nil {
-		h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
-		return
-	}
-
 	// Check if user has write permission
-	canManage := false
-	for _, perm := range permissions {
-		if perm.CanWrite() || perm.CanAdmin() {
-			canManage = true
-			break
+	canManage := h.isAdmin(c)
+	if !canManage {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanWrite() || perm.CanAdmin() {
+				canManage = true
+				break
+			}
 		}
 	}
 
@@ -314,19 +333,19 @@ func (h *JiraConnectionHandler) UpdateCredentials(c *gin.Context) {
 		return
 	}
 
-	// Check project permissions
-	permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
-	if err != nil {
-		h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
-		return
-	}
-
 	// Check if user has write permission
-	canManage := false
-	for _, perm := range permissions {
-		if perm.CanWrite() || perm.CanAdmin() {
-			canManage = true
-			break
+	canManage := h.isAdmin(c)
+	if !canManage {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanWrite() || perm.CanAdmin() {
+				canManage = true
+				break
+			}
 		}
 	}
 
@@ -373,19 +392,19 @@ func (h *JiraConnectionHandler) TestConnection(c *gin.Context) {
 		return
 	}
 
-	// Check project permissions
-	permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
-	if err != nil {
-		h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
-		return
-	}
-
 	// Check if user has write permission
-	canManage := false
-	for _, perm := range permissions {
-		if perm.CanWrite() || perm.CanAdmin() {
-			canManage = true
-			break
+	canManage := h.isAdmin(c)
+	if !canManage {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanWrite() || perm.CanAdmin() {
+				canManage = true
+				break
+			}
 		}
 	}
 
@@ -419,19 +438,19 @@ func (h *JiraConnectionHandler) DeleteConnection(c *gin.Context) {
 		return
 	}
 
-	// Check project permissions
-	permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
-	if err != nil {
-		h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
-		return
-	}
-
 	// Check if user has write permission
-	canManage := false
-	for _, perm := range permissions {
-		if perm.CanWrite() || perm.CanAdmin() {
-			canManage = true
-			break
+	canManage := h.isAdmin(c)
+	if !canManage {
+		permissions, err := h.projectService.GetUserPermissions(c.Request.Context(), projectsDomain.ProjectID(connection.ProjectID()), userID)
+		if err != nil {
+			h.ErrorResponse(c, http.StatusInternalServerError, "failed to get permissions")
+			return
+		}
+		for _, perm := range permissions {
+			if perm.CanWrite() || perm.CanAdmin() {
+				canManage = true
+				break
+			}
 		}
 	}
 

--- a/internal/api/jira_connection_handler_test.go
+++ b/internal/api/jira_connection_handler_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/guidewire-oss/fern-platform/internal/domains/integrations"
+	projectsApp "github.com/guidewire-oss/fern-platform/internal/domains/projects/application"
+	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
+	"github.com/guidewire-oss/fern-platform/pkg/config"
+	"github.com/guidewire-oss/fern-platform/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Fake repos for REST handler tests
+// ---------------------------------------------------------------------------
+
+type jiraHandlerTestConnRepo struct{}
+
+func (r *jiraHandlerTestConnRepo) Create(ctx context.Context, c *integrations.JiraConnection) error {
+	return nil
+}
+func (r *jiraHandlerTestConnRepo) Update(ctx context.Context, c *integrations.JiraConnection) error {
+	return nil
+}
+func (r *jiraHandlerTestConnRepo) Delete(ctx context.Context, id string) error { return nil }
+func (r *jiraHandlerTestConnRepo) FindByID(ctx context.Context, id string) (*integrations.JiraConnection, error) {
+	return nil, nil
+}
+func (r *jiraHandlerTestConnRepo) FindByProjectID(ctx context.Context, projectID string) ([]*integrations.JiraConnection, error) {
+	return nil, nil
+}
+func (r *jiraHandlerTestConnRepo) FindActiveByProjectID(ctx context.Context, projectID string) ([]*integrations.JiraConnection, error) {
+	return nil, nil
+}
+
+type jiraHandlerTestJiraClient struct{}
+
+func (c *jiraHandlerTestJiraClient) TestConnection(ctx context.Context, baseURL, username, credential string, authType integrations.AuthenticationType) error {
+	return nil
+}
+func (c *jiraHandlerTestJiraClient) GetProject(ctx context.Context, baseURL, projectKey, username, credential string, authType integrations.AuthenticationType) (*integrations.JiraProject, error) {
+	return nil, nil
+}
+func (c *jiraHandlerTestJiraClient) ListFields(ctx context.Context, baseURL, username, credential string, authType integrations.AuthenticationType) ([]integrations.JiraField, error) {
+	return nil, nil
+}
+
+type jiraHandlerTestProjectRepo struct{}
+
+func (r *jiraHandlerTestProjectRepo) Save(ctx context.Context, p *projectsDomain.Project) error {
+	return nil
+}
+func (r *jiraHandlerTestProjectRepo) FindByID(ctx context.Context, id uint) (*projectsDomain.Project, error) {
+	return nil, projectsDomain.ErrProjectNotFound
+}
+func (r *jiraHandlerTestProjectRepo) FindByProjectID(ctx context.Context, id projectsDomain.ProjectID) (*projectsDomain.Project, error) {
+	if id == "" {
+		return nil, projectsDomain.ErrProjectNotFound
+	}
+	p, err := projectsDomain.NewProject(id, "Test "+string(id), projectsDomain.Team("test-team"))
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+func (r *jiraHandlerTestProjectRepo) FindByTeam(ctx context.Context, team projectsDomain.Team) ([]*projectsDomain.Project, error) {
+	return nil, nil
+}
+func (r *jiraHandlerTestProjectRepo) FindAll(ctx context.Context, limit, offset int) ([]*projectsDomain.Project, int64, error) {
+	return nil, 0, nil
+}
+func (r *jiraHandlerTestProjectRepo) Update(ctx context.Context, p *projectsDomain.Project) error {
+	return nil
+}
+func (r *jiraHandlerTestProjectRepo) Delete(ctx context.Context, id uint) error { return nil }
+func (r *jiraHandlerTestProjectRepo) ExistsByProjectID(ctx context.Context, id projectsDomain.ProjectID) (bool, error) {
+	return id != "", nil
+}
+
+type jiraHandlerTestPermRepo struct {
+	permissions map[string]projectsDomain.PermissionType
+}
+
+func newJiraHandlerPermRepo(writeUsers ...string) *jiraHandlerTestPermRepo {
+	m := make(map[string]projectsDomain.PermissionType, len(writeUsers))
+	for _, u := range writeUsers {
+		m[u] = projectsDomain.PermissionWrite
+	}
+	return &jiraHandlerTestPermRepo{permissions: m}
+}
+
+func (r *jiraHandlerTestPermRepo) Save(ctx context.Context, p *projectsDomain.ProjectPermission) error {
+	return nil
+}
+func (r *jiraHandlerTestPermRepo) FindByProjectAndUser(ctx context.Context, projectID projectsDomain.ProjectID, userID string) ([]*projectsDomain.ProjectPermission, error) {
+	pt, ok := r.permissions[userID]
+	if !ok {
+		return nil, nil
+	}
+	perm, err := projectsDomain.NewProjectPermission(projectID, userID, pt, "test")
+	if err != nil {
+		return nil, err
+	}
+	return []*projectsDomain.ProjectPermission{perm}, nil
+}
+func (r *jiraHandlerTestPermRepo) FindByUser(ctx context.Context, userID string) ([]*projectsDomain.ProjectPermission, error) {
+	return nil, nil
+}
+func (r *jiraHandlerTestPermRepo) FindByProject(ctx context.Context, projectID projectsDomain.ProjectID) ([]*projectsDomain.ProjectPermission, error) {
+	return nil, nil
+}
+func (r *jiraHandlerTestPermRepo) Delete(ctx context.Context, projectID projectsDomain.ProjectID, userID string, p projectsDomain.PermissionType) error {
+	return nil
+}
+func (r *jiraHandlerTestPermRepo) DeleteExpired(ctx context.Context) error { return nil }
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+func buildJiraConnectionHandler(t *testing.T, permRepo projectsDomain.ProjectPermissionRepository) (*JiraConnectionHandler, *gin.Engine) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger, err := logging.NewLogger(&config.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+
+	key := []byte("0123456789abcdef")
+	connSvc := integrations.NewJiraConnectionService(&jiraHandlerTestConnRepo{}, &jiraHandlerTestJiraClient{}, key)
+	projSvc := projectsApp.NewProjectService(&jiraHandlerTestProjectRepo{}, permRepo)
+
+	base := NewBaseHandler(logger)
+	handler := NewJiraConnectionHandler(base, connSvc, projSvc)
+	router := gin.New()
+	return handler, router
+}
+
+// productionContextMiddleware sets the same gin context keys as the real auth middleware.
+// Critically, it uses "user_role" — NOT "role".
+func productionContextMiddleware(userID, userRole string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("user_id", userID)
+		c.Set("user_role", userRole)
+		c.Next()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestJiraConnectionHandler_AdminBypassesPermissionCheck(t *testing.T) {
+	// admin-1 has no permission row; the admin bypass must still allow access.
+	permRepo := newJiraHandlerPermRepo() // empty — no rows for anyone
+	handler, router := buildJiraConnectionHandler(t, permRepo)
+	router.Use(productionContextMiddleware("admin-1", "admin"))
+	router.GET("/projects/:projectId/jira-connections", handler.GetConnections)
+
+	req := httptest.NewRequest("GET", "/projects/proj-1/jira-connections", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "admin with no permission row must be allowed")
+}
+
+func TestJiraConnectionHandler_NonAdminWithoutPermissionsIsForbidden(t *testing.T) {
+	permRepo := newJiraHandlerPermRepo() // no rows
+	handler, router := buildJiraConnectionHandler(t, permRepo)
+	router.Use(productionContextMiddleware("user-1", "user"))
+	router.GET("/projects/:projectId/jira-connections", handler.GetConnections)
+
+	req := httptest.NewRequest("GET", "/projects/proj-1/jira-connections", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "user with no permission row must be forbidden")
+}
+
+func TestJiraConnectionHandler_NonAdminWithWritePermissionCanView(t *testing.T) {
+	permRepo := newJiraHandlerPermRepo("user-1")
+	handler, router := buildJiraConnectionHandler(t, permRepo)
+	router.Use(productionContextMiddleware("user-1", "user"))
+	router.GET("/projects/:projectId/jira-connections", handler.GetConnections)
+
+	req := httptest.NewRequest("GET", "/projects/proj-1/jira-connections", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "user with write permission must be able to view connections")
+}
+
+func TestJiraConnectionHandler_WrongContextKeyDoesNotBypassAdmin(t *testing.T) {
+	// Regression guard: setting "role" (wrong key) instead of "user_role" must NOT
+	// grant the admin bypass. Before the P0 fix, getUserRole read "role", so setting
+	// only "user_role" would also have been wrong — now "user_role" is the required key.
+	permRepo := newJiraHandlerPermRepo() // no rows
+	handler, router := buildJiraConnectionHandler(t, permRepo)
+	router.Use(func(c *gin.Context) {
+		c.Set("user_id", "admin-1")
+		c.Set("role", "admin") // old/wrong key — must not trigger bypass
+		c.Next()
+	})
+	router.GET("/projects/:projectId/jira-connections", handler.GetConnections)
+
+	req := httptest.NewRequest("GET", "/projects/proj-1/jira-connections", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"setting the wrong context key must not grant admin bypass")
+}
+
+func TestJiraConnectionHandler_UnauthenticatedUserIsRejected(t *testing.T) {
+	permRepo := newJiraHandlerPermRepo()
+	handler, router := buildJiraConnectionHandler(t, permRepo)
+	// No middleware — user_id is not set
+	router.GET("/projects/:projectId/jira-connections", handler.GetConnections)
+
+	req := httptest.NewRequest("GET", "/projects/proj-1/jira-connections", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "request with no user_id must be rejected")
+}

--- a/internal/reporter/graphql/domain_resolvers_jira_mapping.go
+++ b/internal/reporter/graphql/domain_resolvers_jira_mapping.go
@@ -11,11 +11,9 @@ import (
 	"github.com/guidewire-oss/fern-platform/internal/reporter/graphql/model"
 )
 
-// authorizeProjectManagement enforces the canonical per-project authorization
-// used by every JIRA-related resolver. The caller must be authenticated AND
-// hold at least one project-level permission row for `projectID` — global
-// roles alone are not sufficient. Mirrors the pattern in
-// CreateJiraConnection / UpdateJiraConnection (schema.resolvers.go).
+// authorizeProjectManagement checks that the caller is authenticated and holds
+// at least read-level permission on the project (or is an admin). Used by
+// read-only JIRA resolvers (JiraFieldMapping_domain, JiraFields_domain).
 func (r *Resolver) authorizeProjectManagement(ctx context.Context, projectID string) (*authDomain.User, error) {
 	user, err := getCurrentUser(ctx)
 	if err != nil || user == nil {
@@ -30,9 +28,48 @@ func (r *Resolver) authorizeProjectManagement(ctx context.Context, projectID str
 		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
 
-	permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
-	if err != nil || len(permissions) == 0 {
-		return nil, fmt.Errorf("forbidden")
+	if !user.IsAdmin() {
+		permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
+		if err != nil || len(permissions) == 0 {
+			return nil, fmt.Errorf("forbidden")
+		}
+	}
+
+	return user, nil
+}
+
+// authorizeProjectWrite checks that the caller is authenticated and holds
+// write-level permission on the project (or is an admin). Used by all JIRA
+// connection and field-mapping mutation resolvers.
+func (r *Resolver) authorizeProjectWrite(ctx context.Context, projectID string) (*authDomain.User, error) {
+	user, err := getCurrentUser(ctx)
+	if err != nil || user == nil {
+		return nil, fmt.Errorf("unauthorized")
+	}
+
+	project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(projectID))
+	if err != nil {
+		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to get project: %w", err)
+	}
+
+	if !user.IsAdmin() {
+		permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
+		if err != nil {
+			return nil, fmt.Errorf("forbidden")
+		}
+		canWrite := false
+		for _, p := range permissions {
+			if p.CanWrite() || p.CanAdmin() {
+				canWrite = true
+				break
+			}
+		}
+		if !canWrite {
+			return nil, fmt.Errorf("forbidden")
+		}
 	}
 
 	return user, nil
@@ -83,7 +120,7 @@ func (r *queryResolver) JiraFields_domain(ctx context.Context, connectionID stri
 
 // SaveJiraFieldMapping_domain validates and persists a field mapping for the project.
 func (r *mutationResolver) SaveJiraFieldMapping_domain(ctx context.Context, input model.SaveJiraFieldMappingInput) (*model.JiraFieldMapping, error) {
-	user, err := r.authorizeProjectManagement(ctx, input.ProjectID)
+	user, err := r.authorizeProjectWrite(ctx, input.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +154,7 @@ func (r *mutationResolver) SaveJiraFieldMapping_domain(ctx context.Context, inpu
 // ResetJiraFieldMapping_domain deletes any saved mapping for the project and
 // returns the default mapping snapshot.
 func (r *mutationResolver) ResetJiraFieldMapping_domain(ctx context.Context, projectID string) (*model.JiraFieldMapping, error) {
-	if _, err := r.authorizeProjectManagement(ctx, projectID); err != nil {
+	if _, err := r.authorizeProjectWrite(ctx, projectID); err != nil {
 		return nil, err
 	}
 

--- a/internal/reporter/graphql/domain_resolvers_jira_mapping_test.go
+++ b/internal/reporter/graphql/domain_resolvers_jira_mapping_test.go
@@ -170,7 +170,7 @@ func (a *anyProjectRepo) ExistsByProjectID(ctx context.Context, id projectsDomai
 	return id != "", nil
 }
 
-// seededPermissionRepo grants every listed user a Read permission on any
+// seededPermissionRepo grants every listed user a Write permission on any
 // project they're queried for. Users not in the list get no permissions.
 type seededPermissionRepo struct {
 	allowedUsers map[string]struct{}
@@ -191,7 +191,7 @@ func (s *seededPermissionRepo) FindByProjectAndUser(ctx context.Context, project
 	if _, ok := s.allowedUsers[userID]; !ok {
 		return nil, nil
 	}
-	perm, err := projectsDomain.NewProjectPermission(projectID, userID, projectsDomain.PermissionRead, "test-seed")
+	perm, err := projectsDomain.NewProjectPermission(projectID, userID, projectsDomain.PermissionWrite, "test-seed")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/reporter/graphql/domain_resolvers_jira_mapping_test.go
+++ b/internal/reporter/graphql/domain_resolvers_jira_mapping_test.go
@@ -124,13 +124,15 @@ func newTestResolverWithJiraMapping(t *testing.T, mappingSvc *integrations.JiraF
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 
-	// Default permissive project service: any projectID resolves to a project,
-	// and the standard test users "admin-1" and "manager-1" have project-scoped
-	// permissions on every project. Regular users (e.g. "user-1") have none and
-	// are rejected by the new project-scoped auth helper.
+	// Default permissive project service: any projectID resolves to a project.
+	// "admin-1" and "manager-1" hold Write; "reader-1" holds Read.
+	// Regular users (e.g. "user-1") have no row and are rejected by write checks.
 	projSvc := projectsApp.NewProjectService(
 		newAnyProjectRepo(),
-		newSeededPermissionRepo("admin-1", "manager-1"),
+		newMixedPermissionRepo(
+			[]string{"admin-1", "manager-1"},
+			[]string{"reader-1"},
+		),
 	)
 
 	r := NewResolver(nil, projSvc, nil, nil, connSvc, nil, db, logger)
@@ -170,28 +172,33 @@ func (a *anyProjectRepo) ExistsByProjectID(ctx context.Context, id projectsDomai
 	return id != "", nil
 }
 
-// seededPermissionRepo grants every listed user a Write permission on any
-// project they're queried for. Users not in the list get no permissions.
+// seededPermissionRepo grants each seeded user a specific permission on any
+// project they're queried for. Users not in the map get no permissions.
 type seededPermissionRepo struct {
-	allowedUsers map[string]struct{}
+	permissions map[string]projectsDomain.PermissionType
 }
 
-func newSeededPermissionRepo(userIDs ...string) *seededPermissionRepo {
-	s := &seededPermissionRepo{allowedUsers: make(map[string]struct{}, len(userIDs))}
-	for _, u := range userIDs {
-		s.allowedUsers[u] = struct{}{}
+// newMixedPermissionRepo seeds write users with PermissionWrite and read users with PermissionRead.
+func newMixedPermissionRepo(writeUsers, readUsers []string) *seededPermissionRepo {
+	m := make(map[string]projectsDomain.PermissionType, len(writeUsers)+len(readUsers))
+	for _, u := range writeUsers {
+		m[u] = projectsDomain.PermissionWrite
 	}
-	return s
+	for _, u := range readUsers {
+		m[u] = projectsDomain.PermissionRead
+	}
+	return &seededPermissionRepo{permissions: m}
 }
 
 func (s *seededPermissionRepo) Save(ctx context.Context, p *projectsDomain.ProjectPermission) error {
 	return nil
 }
 func (s *seededPermissionRepo) FindByProjectAndUser(ctx context.Context, projectID projectsDomain.ProjectID, userID string) ([]*projectsDomain.ProjectPermission, error) {
-	if _, ok := s.allowedUsers[userID]; !ok {
+	pt, ok := s.permissions[userID]
+	if !ok {
 		return nil, nil
 	}
-	perm, err := projectsDomain.NewProjectPermission(projectID, userID, projectsDomain.PermissionWrite, "test-seed")
+	perm, err := projectsDomain.NewProjectPermission(projectID, userID, pt, "test-seed")
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +236,26 @@ func regularUserCtxForMapping() context.Context {
 		UserID: "user-1",
 		Role:   authDomain.RoleUser,
 		Groups: []authDomain.UserGroup{{GroupName: "team-a"}},
+	})
+}
+
+// readOnlyUserCtxForMapping returns a non-admin user with a PermissionRead row in
+// the seeded permission repo. It must be DENIED writes but ALLOWED reads.
+func readOnlyUserCtxForMapping() context.Context {
+	return context.WithValue(context.Background(), "user", &authDomain.User{
+		UserID: "reader-1",
+		Role:   authDomain.RoleUser,
+		Groups: []authDomain.UserGroup{},
+	})
+}
+
+// unownedAdminCtxForMapping returns an admin user whose UserID has NO permission
+// row in the seeded repo. The admin bypass must shortcut the missing row.
+func unownedAdminCtxForMapping() context.Context {
+	return context.WithValue(context.Background(), "user", &authDomain.User{
+		UserID: "admin-no-row",
+		Role:   authDomain.RoleAdmin,
+		Groups: []authDomain.UserGroup{},
 	})
 }
 
@@ -344,6 +371,41 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, result)
+	})
+
+	t.Run("read-only user is allowed to read the mapping", func(t *testing.T) {
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		snap := buildDefaultSnapshot("proj-1")
+		mapping := integrations.ReconstructJiraFieldMapping("proj-1", snap.Entries, "reader-1", snap.CreatedAt, snap.UpdatedAt)
+		mappingRepo := &fakeMappingRepo{mapping: mapping}
+		mappingSvc := integrations.NewJiraFieldMappingService(mappingRepo, connRepo)
+
+		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
+		qr := &queryResolver{resolver}
+
+		result, err := qr.JiraFieldMapping_domain(readOnlyUserCtxForMapping(), "proj-1")
+
+		require.NoError(t, err, "read-only user must be allowed to read the mapping")
+		require.NotNil(t, result)
+		assert.Equal(t, "proj-1", result.ProjectID)
+	})
+
+	t.Run("admin with no permission row is allowed to read the mapping", func(t *testing.T) {
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		snap := buildDefaultSnapshot("proj-1")
+		mapping := integrations.ReconstructJiraFieldMapping("proj-1", snap.Entries, "admin-no-row", snap.CreatedAt, snap.UpdatedAt)
+		mappingRepo := &fakeMappingRepo{mapping: mapping}
+		mappingSvc := integrations.NewJiraFieldMappingService(mappingRepo, connRepo)
+
+		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
+		qr := &queryResolver{resolver}
+
+		result, err := qr.JiraFieldMapping_domain(unownedAdminCtxForMapping(), "proj-1")
+
+		require.NoError(t, err, "admin must bypass permission check even with no permission row")
+		require.NotNil(t, result)
 	})
 
 	t.Run("unauthenticated request is denied", func(t *testing.T) {
@@ -481,6 +543,40 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 		assert.Contains(t, err.Error(), "forbidden")
 	})
 
+	t.Run("read-only user is denied the write mutation", func(t *testing.T) {
+		// reader-1 has PermissionRead but not PermissionWrite; the write boundary must reject them.
+		activeConn := buildActiveConnection("proj-1")
+		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
+
+		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
+		mr := &mutationResolver{resolver}
+
+		result, err := mr.SaveJiraFieldMapping_domain(readOnlyUserCtxForMapping(), validInput)
+
+		assert.Error(t, err, "read-only user must be denied write access")
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "forbidden")
+	})
+
+	t.Run("admin with no permission row is allowed the write mutation", func(t *testing.T) {
+		// admin-no-row has no permission row but is admin; the bypass must allow them.
+		activeConn := buildActiveConnection("proj-1")
+		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
+
+		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
+		mr := &mutationResolver{resolver}
+
+		result, err := mr.SaveJiraFieldMapping_domain(unownedAdminCtxForMapping(), validInput)
+
+		require.NoError(t, err, "admin must bypass permission check even with no permission row")
+		require.NotNil(t, result)
+		assert.Equal(t, "proj-1", result.ProjectID)
+	})
+
 	t.Run("valid input saves and returns the mapping", func(t *testing.T) {
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
@@ -576,6 +672,36 @@ func TestResetJiraFieldMappingResolver(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "forbidden")
+	})
+
+	t.Run("read-only user is denied the reset mutation", func(t *testing.T) {
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
+
+		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
+		mr := &mutationResolver{resolver}
+
+		result, err := mr.ResetJiraFieldMapping_domain(readOnlyUserCtxForMapping(), "proj-1")
+
+		assert.Error(t, err, "read-only user must be denied reset access")
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "forbidden")
+	})
+
+	t.Run("admin with no permission row is allowed the reset mutation", func(t *testing.T) {
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
+
+		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
+		mr := &mutationResolver{resolver}
+
+		result, err := mr.ResetJiraFieldMapping_domain(unownedAdminCtxForMapping(), "proj-1")
+
+		require.NoError(t, err, "admin must bypass permission check even with no permission row")
+		require.NotNil(t, result)
+		assert.Equal(t, "proj-1", result.ProjectID)
 	})
 
 	t.Run("manager resets and gets default mapping back", func(t *testing.T) {

--- a/internal/reporter/graphql/schema.resolvers.go
+++ b/internal/reporter/graphql/schema.resolvers.go
@@ -7,14 +7,12 @@ package graphql
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
 	authDomain "github.com/guidewire-oss/fern-platform/internal/domains/auth/domain"
 	"github.com/guidewire-oss/fern-platform/internal/domains/integrations"
-	projectsDomain "github.com/guidewire-oss/fern-platform/internal/domains/projects/domain"
 	"github.com/guidewire-oss/fern-platform/internal/reporter/graphql/generated"
 	"github.com/guidewire-oss/fern-platform/internal/reporter/graphql/model"
 	"github.com/guidewire-oss/fern-platform/pkg/database"
@@ -288,24 +286,8 @@ func (r *mutationResolver) ToggleProjectFavorite(ctx context.Context, projectID 
 
 // CreateJiraConnection is the resolver for the createJiraConnection field.
 func (r *mutationResolver) CreateJiraConnection(ctx context.Context, input model.CreateJiraConnectionInput) (*model.JiraConnection, error) {
-	// Check if user can manage the project
-	user, err := getCurrentUser(ctx)
-	if err != nil || user == nil {
-		return nil, fmt.Errorf("unauthorized")
-	}
-
-	project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(input.ProjectID))
-	if err != nil {
-		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("failed to get project: %w", err)
-	}
-
-	// Check if user has manager permissions for this project
-	permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
-	if err != nil || len(permissions) == 0 {
-		return nil, fmt.Errorf("forbidden")
+	if _, err := r.authorizeProjectWrite(ctx, input.ProjectID); err != nil {
+		return nil, err
 	}
 
 	versionFilter := ""
@@ -332,9 +314,7 @@ func (r *mutationResolver) CreateJiraConnection(ctx context.Context, input model
 
 // UpdateJiraConnection is the resolver for the updateJiraConnection field.
 func (r *mutationResolver) UpdateJiraConnection(ctx context.Context, id string, input model.UpdateJiraConnectionInput) (*model.JiraConnection, error) {
-	// Check if user can manage the connection
-	user, err := getCurrentUser(ctx)
-	if err != nil || user == nil {
+	if _, err := getCurrentUser(ctx); err != nil {
 		return nil, fmt.Errorf("unauthorized")
 	}
 
@@ -343,18 +323,8 @@ func (r *mutationResolver) UpdateJiraConnection(ctx context.Context, id string, 
 		return nil, fmt.Errorf("connection not found")
 	}
 
-	project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(connection.ProjectID()))
-	if err != nil {
-		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("failed to get project: %w", err)
-	}
-
-	// Check if user has manager permissions for this project
-	permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
-	if err != nil || len(permissions) == 0 {
-		return nil, fmt.Errorf("forbidden")
+	if _, err := r.authorizeProjectWrite(ctx, connection.ProjectID()); err != nil {
+		return nil, err
 	}
 
 	versionFilter := ""
@@ -378,9 +348,7 @@ func (r *mutationResolver) UpdateJiraConnection(ctx context.Context, id string, 
 
 // UpdateJiraCredentials is the resolver for the updateJiraCredentials field.
 func (r *mutationResolver) UpdateJiraCredentials(ctx context.Context, id string, input model.UpdateJiraCredentialsInput) (*model.JiraConnection, error) {
-	// Check if user can manage the connection
-	user, err := getCurrentUser(ctx)
-	if err != nil || user == nil {
+	if _, err := getCurrentUser(ctx); err != nil {
 		return nil, fmt.Errorf("unauthorized")
 	}
 
@@ -389,18 +357,8 @@ func (r *mutationResolver) UpdateJiraCredentials(ctx context.Context, id string,
 		return nil, fmt.Errorf("connection not found")
 	}
 
-	project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(connection.ProjectID()))
-	if err != nil {
-		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("failed to get project: %w", err)
-	}
-
-	// Check if user has manager permissions for this project
-	permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
-	if err != nil || len(permissions) == 0 {
-		return nil, fmt.Errorf("forbidden")
+	if _, err := r.authorizeProjectWrite(ctx, connection.ProjectID()); err != nil {
+		return nil, err
 	}
 
 	updated, err := r.jiraConnectionService.UpdateCredentials(
@@ -419,9 +377,7 @@ func (r *mutationResolver) UpdateJiraCredentials(ctx context.Context, id string,
 
 // TestJiraConnection is the resolver for the testJiraConnection field.
 func (r *mutationResolver) TestJiraConnection(ctx context.Context, id string) (bool, error) {
-	// Check if user can manage the connection
-	user, err := getCurrentUser(ctx)
-	if err != nil || user == nil {
+	if _, err := getCurrentUser(ctx); err != nil {
 		r.logger.Errorf("TestJiraConnection: unauthorized user")
 		return false, fmt.Errorf("unauthorized")
 	}
@@ -432,23 +388,12 @@ func (r *mutationResolver) TestJiraConnection(ctx context.Context, id string) (b
 		return false, fmt.Errorf("connection not found")
 	}
 
-	project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(connection.ProjectID()))
-	if err != nil {
-		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
-			r.logger.Errorf("TestJiraConnection: project not found: %v", err)
-			return false, err
-		}
-		return false, fmt.Errorf("failed to get project: %w", err)
+	if _, err := r.authorizeProjectWrite(ctx, connection.ProjectID()); err != nil {
+		r.logger.Errorf("TestJiraConnection: authorization failed for connection %s: %v", id, err)
+		return false, err
 	}
 
-	// Check if user has manager permissions for this project
-	permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
-	if err != nil || len(permissions) == 0 {
-		r.logger.Errorf("TestJiraConnection: forbidden for user %s on project %s", user.UserID, project.ProjectID())
-		return false, fmt.Errorf("forbidden")
-	}
-
-	r.logger.Infof("Testing JIRA connection %s for project %s", id, project.ProjectID())
+	r.logger.Infof("Testing JIRA connection %s for project %s", id, connection.ProjectID())
 	if err := r.jiraConnectionService.TestConnection(ctx, id); err != nil {
 		r.logger.Errorf("TestJiraConnection failed: %v", err)
 		return false, nil // Return false but no error so GraphQL returns the boolean
@@ -460,9 +405,7 @@ func (r *mutationResolver) TestJiraConnection(ctx context.Context, id string) (b
 
 // DeleteJiraConnection is the resolver for the deleteJiraConnection field.
 func (r *mutationResolver) DeleteJiraConnection(ctx context.Context, id string) (bool, error) {
-	// Check if user can manage the connection
-	user, err := getCurrentUser(ctx)
-	if err != nil || user == nil {
+	if _, err := getCurrentUser(ctx); err != nil {
 		return false, fmt.Errorf("unauthorized")
 	}
 
@@ -471,18 +414,8 @@ func (r *mutationResolver) DeleteJiraConnection(ctx context.Context, id string) 
 		return false, fmt.Errorf("connection not found")
 	}
 
-	project, err := r.projectService.GetProject(ctx, projectsDomain.ProjectID(connection.ProjectID()))
-	if err != nil {
-		if errors.Is(err, projectsDomain.ErrProjectNotFound) {
-			return false, err
-		}
-		return false, fmt.Errorf("failed to get project: %w", err)
-	}
-
-	// Check if user has manager permissions for this project
-	permissions, err := r.projectService.GetUserPermissions(ctx, project.ProjectID(), user.UserID)
-	if err != nil || len(permissions) == 0 {
-		return false, fmt.Errorf("forbidden")
+	if _, err := r.authorizeProjectWrite(ctx, connection.ProjectID()); err != nil {
+		return false, err
 	}
 
 	if err := r.jiraConnectionService.DeleteConnection(ctx, id); err != nil {


### PR DESCRIPTION
## Summary

- Admin users were blocked from all JIRA connection operations (create, update, test, delete) because the permission check queried `project_permissions` without an
  admin bypass, returning forbidden even for valid admins
- Added missing authorization check to `GetConnections`
- Mutation resolvers now enforce write-level permission, not just project membership
- `SaveJiraFieldMapping` and `ResetJiraFieldMapping` had the same read-vs-write gap
- `getUserID`, `getUserRole`, and `getUserEmail` in the REST handler base would panic on a nil type assertion if the auth middleware didn't populate the context key

## Changes

- Added `authorizeProjectWrite` helper (write-level: `CanWrite` or `CanAdmin`, with admin bypass) alongside the existing read-level `authorizeProjectManagement`
- All JIRA connection and field-mapping mutation resolvers now use `authorizeProjectWrite`; read-only resolvers keep `authorizeProjectManagement`
- REST handlers now gate the `GetUserPermissions` DB call behind `if !isAdmin` — admin users skip the query entirely
- `GetConnections` now enforces project read permission before listing connections
- Fixed unsafe bare type assertions in `getUserID`, `getUserRole`, `getUserEmail`, `getTeamID` to use comma-ok pattern

  ## Test plan

  - [ ] Run `make test` — all unit tests pass
  - [ ] Verify admin user can create/update/test/delete a JIRA connection without being added to `project_permissions`
  - [ ] Verify read-only project member cannot create or save a field mapping
  - [ ] Verify unauthenticated requests return 401, not a panic

  Fixes #192


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds admin bypass and enforces write-level project permissions for all JIRA connection and field-mapping mutations; listing/viewing now require read permission or admin. Aligns HTTP and GraphQL authorization, fixes nil-context panics, and corrects role lookup to `user_role`; addresses Linear #192.

- **Bug Fixes**
  - HTTP: Require write (or admin) for create/update/credentials/test/delete; require read (or admin) for get/list; admin users skip DB permission lookups.
  - GraphQL: Added `authorizeProjectWrite` and updated read helper with admin bypass; mutations and field-mapping save/reset now require write; read-only resolvers enforce read (or admin).
  - Context: `getUserRole` now reads `user_role` (not `role`); context getters return empty strings instead of panicking.

- **Refactors**
  - Consolidated GraphQL permission checks into helpers and removed duplicated inline logic in JIRA resolvers.

<sup>Written for commit cad347fe536c80acbb260145cdfe2e6632c445dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



