### PR TITLE
fix(web): populate header Total Runs and Recent Runs stats (#177)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2573,15 +2573,10 @@
         }
 
         // Modern Header component
-        function Header({ health, projects, testRuns, onOpenSettings }) {
+        function Header({ health, projects, totalRuns = 0, recentRuns = 0, onOpenSettings }) {
             const { theme, toggleTheme } = useUserPreferences();
             const { user, loading, login, logout } = useAuth();
             const activeProjects = projects.filter(p => p.isActive).length;
-            const recentRuns = testRuns.filter(tr => {
-                const runDate = new Date(tr.startTime);
-                const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-                return runDate > dayAgo;
-            }).length;
 
             const getThemeIcon = () => {
                 switch (theme) {
@@ -2632,12 +2627,12 @@
                                     <span className="stat-label">Active Projects</span>
                                 </div>
                                 <div className="stat-item">
-                                    <span className="stat-value">{testRuns.length}</span>
+                                    <span className="stat-value">{totalRuns}</span>
                                     <span className="stat-label">Total Runs</span>
                                 </div>
                                 <div className="stat-item">
                                     <span className="stat-value">{recentRuns}</span>
-                                    <span className="stat-label">Recent Runs</span>
+                                    <span className="stat-label">Recent Runs (24h)</span>
                                 </div>
                             </div>
                             
@@ -8844,7 +8839,7 @@
         // Main App component
         function FernPlatform() {
             const { route, navigate } = useRouter();
-            const [appData, setAppData] = useState({ health: null, projects: [], testRuns: [] });
+            const [appData, setAppData] = useState({ health: null, projects: [], totalRuns: 0, recentRuns: 0 });
             const [showSettings, setShowSettings] = useState(false);
 
             useEffect(() => {
@@ -8863,10 +8858,15 @@
                     // Convert projects from edges format
                     const projectList = projectsData.projects.edges.map(edge => edge.node);
                     
+                    // Total Runs (all-time) and Recent Runs (last 24h) come from the
+                    // dashboard summary counts that are already fetched above, so the
+                    // header stats need no extra network call. Pages still load their
+                    // own detailed test run lists as needed.
                     setAppData({
                         health: summaryData.dashboardSummary.health,
                         projects: projectList,
-                        testRuns: [] // Pages will load their own test runs as needed
+                        totalRuns: summaryData.dashboardSummary.totalTestRuns ?? 0,
+                        recentRuns: summaryData.dashboardSummary.recentTestRuns ?? 0
                     });
                 } catch (err) {
                     console.error('Failed to fetch app data:', err);


### PR DESCRIPTION
## Summary

Fixes #177 — the header's **Total Runs** and **Recent Runs** stats always displayed `0`.

**Root cause:** the `Header` component derived both stats from a `testRuns` prop that `fetchAppData` hardcoded to `[]` (with a "pages load their own runs" comment). `Total Runs` rendered `testRuns.length` and `Recent Runs` filtered the same empty array, so both were always `0`. `Active Projects` worked because it derives from the populated `projects` list.

**Fix:** read the `totalTestRuns` and `recentTestRuns` counts that the existing `GET_DASHBOARD_SUMMARY` query already returns (and were previously fetched but never used), so **no extra network call** is needed.

## Changes (`web/index.html`)

- `Header` now takes `totalRuns` / `recentRuns` props instead of a `testRuns` array; removed the dead client-side 24h filter over the empty array.
- `Total Runs` renders the real `totalTestRuns` count; relabeled **"Recent Runs" → "Recent Runs (24h)"** to match the backend's 24h window (`recentTestRuns`, per `test_run.go`) and the label the Dashboard already uses.
- `fetchAppData` populates `totalRuns`/`recentRuns` from `dashboardSummary`, null-coalesced to `0` for safety; `appData` state shape updated accordingly.

## Testing

- Static verification: confirmed `GET_DASHBOARD_SUMMARY` selects both fields, the resolver populates them (`domain_resolvers.go`), the props are wired through `{...appData}`, and no remaining references to the removed `testRuns` prop / `appData.testRuns`.
- The backend 24h-window count has existing unit coverage (`gorm_test_run_repo_test.go`). No acceptance tests assert on these header labels.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #177 by wiring the header’s Total Runs and Recent Runs to the dashboard summary counts and updating the label to “Recent Runs (24h)”. Removes the unused `testRuns` logic so the stats are accurate.

- **Bug Fixes**
  - Read counts from `dashboardSummary.totalTestRuns` and `dashboardSummary.recentTestRuns` (no extra network call).
  - `Header` now takes `totalRuns` and `recentRuns`; removed `testRuns` prop and the client-side 24h filter.
  - Updated `appData` to include `totalRuns`/`recentRuns` with `0` defaults; label now shows “Recent Runs (24h)”.

<sup>Written for commit 8d894f50ebcf1ef8ed23006116f6474b6caa8d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



