### PR TITLE
fix(jira): don't force domain UUID onto jira_connections primary key #203

### DIFF
--- a/internal/domains/integrations/jira_connection.go
+++ b/internal/domains/integrations/jira_connection.go
@@ -14,26 +14,24 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // JiraConnection represents a JIRA integration connection
 type JiraConnection struct {
-	id                 string
-	projectID          string
-	name               string
-	jiraURL            string
-	authenticationType AuthenticationType
-	projectKey         string
-	username           string
+	id                  string
+	projectID           string
+	name                string
+	jiraURL             string
+	authenticationType  AuthenticationType
+	projectKey          string
+	username            string
 	encryptedCredential string
-	status             ConnectionStatus
-	isActive           bool
-	versionFilter      string
-	lastTestedAt       *time.Time
-	createdAt          time.Time
-	updatedAt          time.Time
+	status              ConnectionStatus
+	isActive            bool
+	versionFilter       string
+	lastTestedAt        *time.Time
+	createdAt           time.Time
+	updatedAt           time.Time
 }
 
 // JiraClient interface for testing connections
@@ -66,18 +64,20 @@ func NewJiraConnection(projectID, name, jiraURL string, authType AuthenticationT
 
 	now := time.Now()
 	return &JiraConnection{
-		id:                 uuid.New().String(),
-		projectID:          projectID,
-		name:               name,
-		jiraURL:            strings.TrimRight(jiraURL, "/"),
-		authenticationType: authType,
-		projectKey:         projectKey,
-		username:           username,
+		// id is intentionally left empty: this connection has no row yet, so
+		// there is no real identity to assign. The repository's Create call
+		// sets the database-assigned numeric ID via SetID after insert.
+		projectID:           projectID,
+		name:                name,
+		jiraURL:             strings.TrimRight(jiraURL, "/"),
+		authenticationType:  authType,
+		projectKey:          projectKey,
+		username:            username,
 		encryptedCredential: credential, // Will be encrypted when saved
-		status:             ConnectionStatusPending,
-		isActive:           false,
-		createdAt:          now,
-		updatedAt:          now,
+		status:              ConnectionStatusPending,
+		isActive:            false,
+		createdAt:           now,
+		updatedAt:           now,
 	}, nil
 }
 
@@ -147,9 +147,9 @@ func (j *JiraConnection) LastTestedAt() *time.Time {
 	return j.lastTestedAt
 }
 
-// SetID replaces the connection's identifier. Used by the repository after a
-// successful insert to replace the throwaway construction-time ID with the
-// real database-assigned primary key.
+// SetID assigns the connection's identifier. Used by the repository after a
+// successful insert to give a newly-created connection its real
+// database-assigned primary key.
 func (j *JiraConnection) SetID(id string) {
 	j.id = id
 }
@@ -204,7 +204,7 @@ func (j *JiraConnection) UpdateCredentials(authType AuthenticationType, username
 // TestConnection tests the JIRA connection
 func (j *JiraConnection) TestConnection(ctx context.Context, client JiraClient) error {
 	log.Printf("[JiraConnection] Testing connection for ID: %s, URL: %s", j.id, j.jiraURL)
-	
+
 	err := client.TestConnection(ctx, j.jiraURL, j.username, j.encryptedCredential, j.authenticationType)
 	now := time.Now()
 	j.lastTestedAt = &now

--- a/internal/domains/integrations/jira_connection.go
+++ b/internal/domains/integrations/jira_connection.go
@@ -147,6 +147,13 @@ func (j *JiraConnection) LastTestedAt() *time.Time {
 	return j.lastTestedAt
 }
 
+// SetID replaces the connection's identifier. Used by the repository after a
+// successful insert to replace the throwaway construction-time ID with the
+// real database-assigned primary key.
+func (j *JiraConnection) SetID(id string) {
+	j.id = id
+}
+
 // CreatedAt returns when the connection was created
 func (j *JiraConnection) CreatedAt() time.Time {
 	return j.createdAt

--- a/internal/domains/integrations/jira_connection_test.go
+++ b/internal/domains/integrations/jira_connection_test.go
@@ -152,7 +152,9 @@ func TestNewJiraConnection(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				require.NotNil(t, conn)
-				assert.NotEmpty(t, conn.ID())
+				// An unsaved connection has no identity yet -- the repository
+				// assigns the real numeric ID on Create and calls SetID.
+				assert.Empty(t, conn.ID())
 				assert.Equal(t, tt.projectID, conn.ProjectID())
 				assert.Equal(t, tt.connName, conn.Name())
 				assert.Equal(t, tt.jiraURL, conn.JiraURL())

--- a/internal/infrastructure/repositories/gorm_jira_connection_repository.go
+++ b/internal/infrastructure/repositories/gorm_jira_connection_repository.go
@@ -20,11 +20,19 @@ func NewGormJiraConnectionRepository(db *gorm.DB) integrations.JiraConnectionRep
 // Create saves a new JIRA connection
 func (r *GormJiraConnectionRepository) Create(ctx context.Context, connection *integrations.JiraConnection) error {
 	model := r.toModel(connection)
-	
+	// toModel() populates ID for the Update path, where the domain object
+	// already carries a real numeric row ID as a string. A brand-new
+	// connection instead carries a throwaway construction-time UUID, which
+	// must never be forced onto the insert -- the database assigns the real
+	// primary key.
+	model.ID = 0
+
 	if err := r.db.WithContext(ctx).Create(&model).Error; err != nil {
 		return fmt.Errorf("failed to create JIRA connection: %w", err)
 	}
-	
+
+	connection.SetID(fmt.Sprintf("%d", model.ID))
+
 	return nil
 }
 

--- a/internal/infrastructure/repositories/gorm_jira_connection_repository.go
+++ b/internal/infrastructure/repositories/gorm_jira_connection_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/guidewire-oss/fern-platform/internal/domains/integrations"
 	"github.com/guidewire-oss/fern-platform/pkg/database"
@@ -19,16 +20,21 @@ func NewGormJiraConnectionRepository(db *gorm.DB) integrations.JiraConnectionRep
 
 // Create saves a new JIRA connection
 func (r *GormJiraConnectionRepository) Create(ctx context.Context, connection *integrations.JiraConnection) error {
-	model := r.toModel(connection)
-	// toModel() populates ID for the Update path, where the domain object
-	// already carries a real numeric row ID as a string. A brand-new
-	// connection instead carries a throwaway construction-time UUID, which
-	// must never be forced onto the insert -- the database assigns the real
-	// primary key.
+	// A brand-new connection's domain ID is empty (see NewJiraConnection),
+	// so toModel already leaves model.ID at 0 here. The explicit reset is a
+	// defensive guard, not a no-op: it ensures Create never lets any
+	// pre-existing ID reach the insert, even from a mis-constructed domain
+	// object (e.g. the throwaway UUID a prior version of NewJiraConnection
+	// used to mint) -- the database always assigns the real primary key.
+	model, _ := r.toModel(connection)
 	model.ID = 0
 
 	if err := r.db.WithContext(ctx).Create(&model).Error; err != nil {
 		return fmt.Errorf("failed to create JIRA connection: %w", err)
+	}
+
+	if model.ID == 0 {
+		return fmt.Errorf("JIRA connection created but no row ID was returned by the database")
 	}
 
 	connection.SetID(fmt.Sprintf("%d", model.ID))
@@ -38,12 +44,18 @@ func (r *GormJiraConnectionRepository) Create(ctx context.Context, connection *i
 
 // Update updates an existing JIRA connection
 func (r *GormJiraConnectionRepository) Update(ctx context.Context, connection *integrations.JiraConnection) error {
-	model := r.toModel(connection)
-	
+	model, err := r.toModel(connection)
+	if err != nil {
+		return fmt.Errorf("failed to update JIRA connection: %w", err)
+	}
+	if model.ID == 0 {
+		return fmt.Errorf("cannot update JIRA connection with unset row ID")
+	}
+
 	if err := r.db.WithContext(ctx).Save(&model).Error; err != nil {
 		return fmt.Errorf("failed to update JIRA connection: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -102,8 +114,11 @@ func (r *GormJiraConnectionRepository) FindActiveByProjectID(ctx context.Context
 	return connections, nil
 }
 
-// toModel converts a domain entity to a database model
-func (r *GormJiraConnectionRepository) toModel(conn *integrations.JiraConnection) *database.JiraConnection {
+// toModel converts a domain entity to a database model. A non-empty domain
+// ID must be a valid numeric row ID -- callers that don't yet have a real
+// row ID (e.g. Create, before the DB assigns one) should discard the error
+// and force model.ID to 0 themselves.
+func (r *GormJiraConnectionRepository) toModel(conn *integrations.JiraConnection) (*database.JiraConnection, error) {
 	snapshot := conn.Snapshot()
 	model := &database.JiraConnection{
 		ProjectID:           snapshot.ProjectID,
@@ -118,21 +133,23 @@ func (r *GormJiraConnectionRepository) toModel(conn *integrations.JiraConnection
 		VersionFilter:       snapshot.VersionFilter,
 		LastTestedAt:        snapshot.LastTestedAt,
 	}
-	
-	// CRITICAL: Set the ID to ensure updates work correctly
-	// Convert string ID to uint (assuming numeric IDs)
-	if id := snapshot.ID; id != "" {
-		var numericID uint
-		if _, err := fmt.Sscanf(id, "%d", &numericID); err == nil {
-			model.ID = numericID
-		}
-	}
-	
-	// Set timestamps if they exist
+
 	model.CreatedAt = snapshot.CreatedAt
 	model.UpdatedAt = snapshot.UpdatedAt
-	
-	return model
+
+	if id := snapshot.ID; id != "" {
+		// Parse at uint's actual bit width (32 on a 32-bit platform), not a
+		// hardcoded 64: ParseUint(..., 64) always returns a uint64, and
+		// converting that down to uint would silently wrap an out-of-range
+		// value instead of rejecting it.
+		numericID, err := strconv.ParseUint(id, 10, strconv.IntSize)
+		if err != nil {
+			return model, fmt.Errorf("invalid JIRA connection ID %q: %w", id, err)
+		}
+		model.ID = uint(numericID)
+	}
+
+	return model, nil
 }
 
 // toDomain converts a database model to a domain entity

--- a/internal/infrastructure/repositories/gorm_jira_connection_repository_test.go
+++ b/internal/infrastructure/repositories/gorm_jira_connection_repository_test.go
@@ -1,0 +1,120 @@
+package repositories_test
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/guidewire-oss/fern-platform/internal/domains/integrations"
+	"github.com/guidewire-oss/fern-platform/internal/infrastructure/repositories"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupJiraConnectionMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *gorm.DB) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	return db, mock, gormDB
+}
+
+// A freshly constructed connection carries a UUID as its domain ID (see
+// integrations.NewJiraConnection). This particular value starts with a
+// decimal digit run before the first hex letter, which is exactly the shape
+// that fmt.Sscanf(id, "%d", ...) silently parses as a small integer.
+const uuidLikeDomainID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+func makeNewJiraConnection(t *testing.T) *integrations.JiraConnection {
+	t.Helper()
+	return integrations.ReconstructJiraConnection(
+		uuidLikeDomainID,
+		"proj-abc",
+		"My Connection",
+		"https://jira.example.com",
+		integrations.AuthTypeAPIToken,
+		"PROJ",
+		"user@example.com",
+		"encrypted-credential",
+		integrations.ConnectionStatusPending,
+		false,
+		"",
+		nil,
+		time.Now(),
+		time.Now(),
+	)
+}
+
+func TestGormJiraConnectionRepository_Create(t *testing.T) {
+	t.Run("does not force the domain's UUID onto the primary key column", func(t *testing.T) {
+		sqlDB, mock, gormDB := setupJiraConnectionMockDB(t)
+		defer sqlDB.Close()
+
+		repo := repositories.NewGormJiraConnectionRepository(gormDB)
+		conn := makeNewJiraConnection(t)
+
+		// Exactly 14 columns, none of them "id" -- the database must assign
+		// the primary key. If the buggy code parses the leading digits of the
+		// UUID into model.ID, GORM adds an extra "id" argument here and this
+		// expectation (14 AnyArg()s) fails to match.
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "jira_connections"`)).
+			WithArgs(
+				sqlmock.AnyArg(), // created_at
+				sqlmock.AnyArg(), // updated_at
+				sqlmock.AnyArg(), // deleted_at
+				sqlmock.AnyArg(), // project_id
+				sqlmock.AnyArg(), // name
+				sqlmock.AnyArg(), // jira_url
+				sqlmock.AnyArg(), // authentication_type
+				sqlmock.AnyArg(), // project_key
+				sqlmock.AnyArg(), // username
+				sqlmock.AnyArg(), // encrypted_credential
+				sqlmock.AnyArg(), // status
+				sqlmock.AnyArg(), // is_active
+				sqlmock.AnyArg(), // last_tested_at
+				sqlmock.AnyArg(), // version_filter
+			).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+		mock.ExpectCommit()
+
+		err := repo.Create(context.Background(), conn)
+
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("propagates the database-assigned ID back onto the domain object", func(t *testing.T) {
+		sqlDB, mock, gormDB := setupJiraConnectionMockDB(t)
+		defer sqlDB.Close()
+
+		repo := repositories.NewGormJiraConnectionRepository(gormDB)
+		conn := makeNewJiraConnection(t)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "jira_connections"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(42))
+		mock.ExpectCommit()
+
+		err := repo.Create(context.Background(), conn)
+
+		require.NoError(t, err)
+		// Subsequent lookups (test/update/delete) key off conn.ID(), which is
+		// compared against a uint primary key column -- it must reflect the
+		// real row id, not the throwaway UUID minted at construction time.
+		assert.Equal(t, "42", conn.ID())
+	})
+}

--- a/internal/infrastructure/repositories/gorm_jira_connection_repository_test.go
+++ b/internal/infrastructure/repositories/gorm_jira_connection_repository_test.go
@@ -120,6 +120,7 @@ func TestGormJiraConnectionRepository_Create(t *testing.T) {
 		// compared against a uint primary key column -- it must reflect the
 		// real row id, not the throwaway UUID minted at construction time.
 		assert.Equal(t, "42", conn.ID())
+		assert.NoError(t, mock.ExpectationsWereMet())
 	})
 
 	t.Run("errors instead of stamping a zero ID when the driver returns no primary key", func(t *testing.T) {

--- a/internal/infrastructure/repositories/gorm_jira_connection_repository_test.go
+++ b/internal/infrastructure/repositories/gorm_jira_connection_repository_test.go
@@ -32,10 +32,14 @@ func setupJiraConnectionMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *gorm.DB
 	return db, mock, gormDB
 }
 
-// A freshly constructed connection carries a UUID as its domain ID (see
-// integrations.NewJiraConnection). This particular value starts with a
-// decimal digit run before the first hex letter, which is exactly the shape
-// that fmt.Sscanf(id, "%d", ...) silently parses as a small integer.
+// A freshly constructed connection's domain ID is actually empty (see
+// integrations.NewJiraConnection) -- this simulates a mis-constructed
+// domain object carrying a non-empty, non-row ID instead, the shape of bug
+// a prior version of NewJiraConnection used to produce before it was fixed
+// to leave new connections' IDs empty. This particular value starts with a
+// decimal digit run before the first hex letter, which is exactly the
+// shape that fmt.Sscanf(id, "%d", ...) used to silently parse as a small
+// integer.
 const uuidLikeDomainID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
 
 func makeNewJiraConnection(t *testing.T) *integrations.JiraConnection {
@@ -116,5 +120,102 @@ func TestGormJiraConnectionRepository_Create(t *testing.T) {
 		// compared against a uint primary key column -- it must reflect the
 		// real row id, not the throwaway UUID minted at construction time.
 		assert.Equal(t, "42", conn.ID())
+	})
+
+	t.Run("errors instead of stamping a zero ID when the driver returns no primary key", func(t *testing.T) {
+		sqlDB, mock, gormDB := setupJiraConnectionMockDB(t)
+		defer sqlDB.Close()
+
+		repo := repositories.NewGormJiraConnectionRepository(gormDB)
+		conn := makeNewJiraConnection(t)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "jira_connections"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		mock.ExpectCommit()
+
+		err := repo.Create(context.Background(), conn)
+
+		require.Error(t, err)
+		// The domain object must keep its original (throwaway) ID rather than
+		// being stamped with "0", which would collide with every other
+		// connection that also failed to get a real PK back.
+		assert.Equal(t, uuidLikeDomainID, conn.ID())
+	})
+}
+
+func makeExistingJiraConnection(t *testing.T, id string) *integrations.JiraConnection {
+	t.Helper()
+	return integrations.ReconstructJiraConnection(
+		id,
+		"proj-abc",
+		"My Connection",
+		"https://jira.example.com",
+		integrations.AuthTypeAPIToken,
+		"PROJ",
+		"user@example.com",
+		"encrypted-credential",
+		integrations.ConnectionStatusPending,
+		false,
+		"",
+		nil,
+		time.Now(),
+		time.Now(),
+	)
+}
+
+func TestGormJiraConnectionRepository_Update(t *testing.T) {
+	t.Run("updates using the numeric row ID parsed from the domain object", func(t *testing.T) {
+		sqlDB, mock, gormDB := setupJiraConnectionMockDB(t)
+		defer sqlDB.Close()
+
+		repo := repositories.NewGormJiraConnectionRepository(gormDB)
+		conn := makeExistingJiraConnection(t, "42")
+
+		mock.ExpectBegin()
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "jira_connections" SET`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+
+		err := repo.Update(context.Background(), conn)
+
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns an error instead of silently inserting a duplicate row when the domain ID is not numeric", func(t *testing.T) {
+		sqlDB, mock, gormDB := setupJiraConnectionMockDB(t)
+		defer sqlDB.Close()
+
+		repo := repositories.NewGormJiraConnectionRepository(gormDB)
+		// Same shape of bug the Create fix targets: a non-numeric ID (e.g. a
+		// UUID from a mis-reconstructed domain object) must never be
+		// silently coerced -- that previously produced a truncated integer
+		// via fmt.Sscanf, which Save() could then INSERT as a new row.
+		conn := makeExistingJiraConnection(t, uuidLikeDomainID)
+
+		err := repo.Update(context.Background(), conn)
+
+		// Must be rejected by our own validation, not surfaced as a generic
+		// "unexpected DB call" error from an un-mocked query -- that would
+		// mean the bad ID reached Save() and, in a real DB, could silently
+		// insert a duplicate row instead of failing loudly.
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns an error instead of inserting when the domain ID is unset", func(t *testing.T) {
+		sqlDB, mock, gormDB := setupJiraConnectionMockDB(t)
+		defer sqlDB.Close()
+
+		repo := repositories.NewGormJiraConnectionRepository(gormDB)
+		conn := makeExistingJiraConnection(t, "")
+
+		err := repo.Update(context.Background(), conn)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unset")
+		assert.NoError(t, mock.ExpectationsWereMet())
 	})
 }


### PR DESCRIPTION
Quirky error - see the issue for full details, but the GormJiraConnectionRepository.toModel() for a new connection was getting a UUID as the primary key. The processing of this primary key will not reject a UUID if it starts with an integer - but when it goes into the DB it fails. The fix is to not initialize the ID with a UUID


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing client-generated IDs into `jira_connections`. New connections no longer mint UUIDs; the DB assigns the numeric PK, which we propagate back. Invalid or missing IDs are rejected to fix #203.

- **Bug Fixes**
  - `NewJiraConnection`: no UUID; new connections start with empty ID. Added `SetID` to assign the DB PK after insert.
  - Repository `Create`: force `model.ID = 0`, insert, require a returned non-zero `id`, then propagate it to the domain.
  - Repository `Update`: parse and validate the domain ID as numeric; error on non-numeric or unset IDs.
  - `toModel`: now returns `(model, error)`; uses `strconv.ParseUint` with `strconv.IntSize` for safe parsing and preserves timestamps.
  - Tests (`sqlmock`): verify no `id` in INSERT, domain ID propagation, error when no PK is returned, numeric-ID updates, validation failures, and expectations are met.

<sup>Written for commit e89e38479a678762067af3c386d7e823fd347113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



