### PR TITLE
fix(jira): make JIRA_ENCRYPTION_KEY optional and disable UI when unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Docker images will be available after the v0.1.0 release:
 - Docker Hub: `docker.io/guidewireoss/fern-platform:latest`
 
 ```bash
+# Generate JIRA encryption key (optional, only needed if using JIRA integration)
+JIRA_KEY=$(openssl rand -hex 32)
+
 # Future usage (not yet available):
 docker run -d \
   --name fern-platform \
@@ -65,6 +68,7 @@ docker run -d \
   -e DB_PASSWORD=yourpassword \
   -e DB_NAME=fern_platform \
   -e REDIS_HOST=host.docker.internal \
+  -e JIRA_ENCRYPTION_KEY=$JIRA_KEY \
   ghcr.io/guidewire-oss/fern-platform:latest
 ```
 

--- a/deployments/fern-platform-kubevela.yaml
+++ b/deployments/fern-platform-kubevela.yaml
@@ -853,6 +853,12 @@ spec:
             value: "" # Empty for local development (use current domain)
           - name: COOKIE_SECURE
             value: "false" # HTTP for local k3d
+
+          # JIRA Integration (Optional)
+          # Generate with: openssl rand -hex 32
+          # Only required if using JIRA integration; leave empty to disable
+          - name: JIRA_ENCRYPTION_KEY
+            value: ""
           - name: TRUST_PROXY
             value: "false" # No proxy in local k3d
         resources:

--- a/docs/all-docs.md
+++ b/docs/all-docs.md
@@ -32,6 +32,7 @@
 
 ### Configuration
 - [OAuth Setup](./configuration/oauth.md) - Authentication configuration
+- [JIRA Integration](./configuration/jira-integration.md) - Set up JIRA integration (optional)
 - [Permissions System](./configuration/scope-based-permissions.md) - Role-based access control
 - [Permission Examples](./configuration/scope-examples.md) - Common permission scenarios
 - [Test Users](./configuration/test-users.md) - Pre-configured test accounts

--- a/docs/configuration/jira-integration.md
+++ b/docs/configuration/jira-integration.md
@@ -1,0 +1,207 @@
+# JIRA Integration Configuration
+
+Fern Platform supports integration with JIRA to enable:
+- Project management connector workflows
+- Test tagging with JIRA issue IDs
+- Field mapping between JIRA and Fern Platform
+- Requirements traceability
+
+## Is JIRA Integration Optional?
+
+**Yes.** JIRA integration is completely optional. The Fern Platform works perfectly without it. Only configure JIRA integration if your team uses JIRA and wants to link test results with JIRA issues.
+
+## Setup
+
+### Prerequisites
+
+JIRA integration requires an encryption key to securely store JIRA credentials.
+
+### 1. Generate Encryption Key
+
+Generate a new 64-character hex string (32 bytes):
+
+```bash
+openssl rand -hex 32
+```
+
+Example output:
+```
+a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6
+```
+
+### 2. Set Environment Variable
+
+Configure the encryption key for your deployment:
+
+#### Local Development
+
+```bash
+export JIRA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+go run cmd/fern-platform/main.go
+```
+
+#### Docker Compose
+
+Update `docker-compose.yml`:
+
+```yaml
+services:
+  fern-platform:
+    environment:
+      JIRA_ENCRYPTION_KEY: "your-64-char-hex-string"
+```
+
+Run:
+```bash
+docker-compose up -d
+```
+
+#### Kubernetes / KubeVela
+
+Update `deployments/fern-platform-kubevela.yaml`:
+
+```yaml
+spec:
+  components:
+    - type: webservice
+      properties:
+        env:
+          - name: JIRA_ENCRYPTION_KEY
+            value: "your-64-char-hex-string"
+```
+
+Then deploy:
+```bash
+kubectl apply -f deployments/fern-platform-kubevela.yaml
+```
+
+#### Environment File (.env)
+
+Create a `.env` file (not committed to git):
+
+```bash
+JIRA_ENCRYPTION_KEY=your-64-char-hex-string
+```
+
+Load before running:
+```bash
+source .env
+go run cmd/fern-platform/main.go
+```
+
+### 3. Start the Application
+
+Once `JIRA_ENCRYPTION_KEY` is set, start Fern Platform:
+
+```bash
+go run cmd/fern-platform/main.go
+```
+
+Or restart your container/pod:
+```bash
+docker-compose restart fern-platform
+kubectl rollout restart deployment/fern-platform -n fern-platform
+```
+
+## What Happens If JIRA_ENCRYPTION_KEY Is Not Set?
+
+If you do not set `JIRA_ENCRYPTION_KEY`:
+- The application starts normally
+- JIRA integration features are disabled
+- The Fern Platform UI does not show JIRA connection options
+- Test results continue to be aggregated normally
+- You can enable JIRA integration later by setting the variable and restarting
+
+## What Happens If JIRA_ENCRYPTION_KEY Is Invalid?
+
+The application will fail at startup with a clear error message:
+
+```
+panic: JIRA_ENCRYPTION_KEY is not valid hex: encoding/hex: invalid byte
+```
+
+or
+
+```
+panic: JIRA_ENCRYPTION_KEY must decode to exactly 32 bytes, got 24
+```
+
+**Fix:** Generate a new 64-character hex string with `openssl rand -hex 32` and update the configuration.
+
+## Key Rotation
+
+To rotate the encryption key:
+
+1. **Generate a new key:**
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. **Update all JIRA connections** to re-encrypt credentials with the new key
+   - This happens automatically when the application restarts
+   - Existing credentials are decrypted with the old key and re-encrypted with the new key
+
+3. **Update the environment variable** in your deployment configuration
+
+4. **Restart the application**
+
+## Security Best Practices
+
+1. **Use a strong, random key** — Always generate with `openssl rand -hex 32`, never use hardcoded values
+2. **Secure storage** — Store the key in:
+   - Kubernetes Secrets (not ConfigMaps)
+   - AWS Secrets Manager, HashiCorp Vault, or similar
+   - Environment-specific `.env` files (add to `.gitignore`)
+   - Never commit to version control
+3. **Access control** — Limit who has access to the key
+4. **Rotation** — Rotate keys periodically (every 90 days recommended)
+5. **Audit** — Log access to JIRA credentials and JIRA operations
+
+## Troubleshooting
+
+### Application won't start: "JIRA_ENCRYPTION_KEY not valid"
+
+**Problem:** The encryption key is not a valid 64-character hex string
+
+**Solution:**
+```bash
+# Generate a new key
+JIRA_KEY=$(openssl rand -hex 32)
+echo $JIRA_KEY  # Verify it's 64 characters
+
+# Set it in your environment or deployment
+export JIRA_ENCRYPTION_KEY=$JIRA_KEY
+```
+
+### JIRA buttons don't appear in the UI
+
+**Problem:** JIRA integration features are not visible
+
+**Solution:** The application started without `JIRA_ENCRYPTION_KEY` set
+```bash
+# Set the environment variable
+export JIRA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
+# Restart the application
+```
+
+### "JIRA integration is not configured" error when creating a connection
+
+**Problem:** The application was restarted without the encryption key
+
+**Solution:** Ensure `JIRA_ENCRYPTION_KEY` is set in your environment before starting the application:
+```bash
+# Check if the variable is set
+echo $JIRA_ENCRYPTION_KEY
+
+# If empty, set it:
+export JIRA_ENCRYPTION_KEY=your-64-char-hex-string
+
+# Restart the application
+```
+
+## See Also
+
+- [JIRA Integration Gap Analysis](../analysis/jira-integration-gap-analysis.md)
+- [PM Connectors Management](../use-cases/10-pm-connectors-management.md)
+- [Requirements Traceability RFC](../rfc/rfc-003-requirements-traceability-and-test-coverage-intelligence.md)

--- a/docs/developers/quick-start.md
+++ b/docs/developers/quick-start.md
@@ -71,12 +71,17 @@ services:
       DB_HOST: postgres
       DB_PASSWORD: postgres
       REDIS_HOST: redis
+      # Optional: Only needed if using JIRA integration
+      # Generate with: openssl rand -hex 32
+      JIRA_ENCRYPTION_KEY: ""
     depends_on:
       - postgres
       - redis
 ```
 
 Run: `docker-compose up -d`
+
+> **Note**: Set `JIRA_ENCRYPTION_KEY` to a 64-character hex string (generated with `openssl rand -hex 32`) only if you plan to use JIRA integration. If not using JIRA, you can leave it empty.
 
 Visit `http://localhost:8080`
 
@@ -435,6 +440,9 @@ Set your environment variables:
 ```bash
 export FERN_URL=http://fern-platform.local:8080
 export FERN_PROJECT_ID=your-project-id
+
+# Optional: Only if using JIRA integration
+export JIRA_ENCRYPTION_KEY=$(openssl rand -hex 32)
 ```
 
 Run your tests as usual - results will automatically appear in Fern Platform!
@@ -525,6 +533,7 @@ Copy this checklist to track your progress:
 - [ ] Submitted first test data via API
 - [ ] Test run appears in dashboard
 - [ ] Configured CI/CD integration (optional)
+- [ ] Set up JIRA integration (optional, see [JIRA Integration Guide](../configuration/jira-integration.md))
 - [ ] Added AI API keys (optional)
 
 ### Next Steps

--- a/docs/installation/local-k3d.md
+++ b/docs/installation/local-k3d.md
@@ -31,6 +31,17 @@ sudo sh -c 'echo "127.0.0.1 keycloak" >> /etc/hosts'
 cat /etc/hosts | grep -E "fern-platform|keycloak"
 ```
 
+## Environment Configuration
+
+Before deploying, optionally set up JIRA integration (if using JIRA):
+
+```bash
+# Generate JIRA encryption key (only needed if using JIRA integration)
+export JIRA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+
+# For production, store this securely and provide it to your deployment
+```
+
 ## Quick Start
 
 ### 1. Setup Script
@@ -46,6 +57,7 @@ This will:
 - Install all dependencies
 - Build and deploy Fern Platform
 - Configure networking
+- Set up JIRA integration (if JIRA_ENCRYPTION_KEY is configured)
 
 ### 2. Manual Setup
 

--- a/internal/api/jira_connection_handler.go
+++ b/internal/api/jira_connection_handler.go
@@ -106,11 +106,6 @@ type JiraConnectionResponse struct {
 
 // CreateConnection creates a new JIRA connection
 func (h *JiraConnectionHandler) CreateConnection(c *gin.Context) {
-	if !h.jiraService.IsEnabled() {
-		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
-		return
-	}
-
 	projectID := c.Param("projectId")
 
 	// Check if user can manage the project
@@ -138,6 +133,13 @@ func (h *JiraConnectionHandler) CreateConnection(c *gin.Context) {
 
 	if !canManage {
 		h.ErrorResponse(c, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	// Checked after authn/authz so an unauthenticated or unauthorized caller
+	// never learns whether JIRA is configured on this server.
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
 		return
 	}
 
@@ -258,11 +260,6 @@ func (h *JiraConnectionHandler) GetConnection(c *gin.Context) {
 
 // UpdateConnection updates a JIRA connection
 func (h *JiraConnectionHandler) UpdateConnection(c *gin.Context) {
-	if !h.jiraService.IsEnabled() {
-		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
-		return
-	}
-
 	connectionID := c.Param("connectionId")
 
 	// Check if user can manage the connection
@@ -296,6 +293,13 @@ func (h *JiraConnectionHandler) UpdateConnection(c *gin.Context) {
 
 	if !canManage {
 		h.ErrorResponse(c, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	// Checked after authn/authz so an unauthenticated or unauthorized caller
+	// never learns whether JIRA is configured on this server.
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
 		return
 	}
 
@@ -328,11 +332,6 @@ func (h *JiraConnectionHandler) UpdateConnection(c *gin.Context) {
 
 // UpdateCredentials updates JIRA connection credentials
 func (h *JiraConnectionHandler) UpdateCredentials(c *gin.Context) {
-	if !h.jiraService.IsEnabled() {
-		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
-		return
-	}
-
 	connectionID := c.Param("connectionId")
 
 	// Check if user can manage the connection
@@ -366,6 +365,13 @@ func (h *JiraConnectionHandler) UpdateCredentials(c *gin.Context) {
 
 	if !canManage {
 		h.ErrorResponse(c, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	// Checked after authn/authz so an unauthenticated or unauthorized caller
+	// never learns whether JIRA is configured on this server.
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
 		return
 	}
 
@@ -392,11 +398,6 @@ func (h *JiraConnectionHandler) UpdateCredentials(c *gin.Context) {
 
 // TestConnection tests a JIRA connection
 func (h *JiraConnectionHandler) TestConnection(c *gin.Context) {
-	if !h.jiraService.IsEnabled() {
-		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
-		return
-	}
-
 	connectionID := c.Param("connectionId")
 
 	// Check if user can manage the connection
@@ -430,6 +431,13 @@ func (h *JiraConnectionHandler) TestConnection(c *gin.Context) {
 
 	if !canManage {
 		h.ErrorResponse(c, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	// Checked after authn/authz so an unauthenticated or unauthorized caller
+	// never learns whether JIRA is configured on this server.
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
 		return
 	}
 

--- a/internal/api/jira_connection_handler.go
+++ b/internal/api/jira_connection_handler.go
@@ -106,8 +106,13 @@ type JiraConnectionResponse struct {
 
 // CreateConnection creates a new JIRA connection
 func (h *JiraConnectionHandler) CreateConnection(c *gin.Context) {
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
+		return
+	}
+
 	projectID := c.Param("projectId")
-	
+
 	// Check if user can manage the project
 	userID := h.getUserID(c)
 	if userID == "" {
@@ -253,8 +258,13 @@ func (h *JiraConnectionHandler) GetConnection(c *gin.Context) {
 
 // UpdateConnection updates a JIRA connection
 func (h *JiraConnectionHandler) UpdateConnection(c *gin.Context) {
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
+		return
+	}
+
 	connectionID := c.Param("connectionId")
-	
+
 	// Check if user can manage the connection
 	userID := h.getUserID(c)
 	if userID == "" {
@@ -318,8 +328,13 @@ func (h *JiraConnectionHandler) UpdateConnection(c *gin.Context) {
 
 // UpdateCredentials updates JIRA connection credentials
 func (h *JiraConnectionHandler) UpdateCredentials(c *gin.Context) {
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
+		return
+	}
+
 	connectionID := c.Param("connectionId")
-	
+
 	// Check if user can manage the connection
 	userID := h.getUserID(c)
 	if userID == "" {
@@ -377,8 +392,13 @@ func (h *JiraConnectionHandler) UpdateCredentials(c *gin.Context) {
 
 // TestConnection tests a JIRA connection
 func (h *JiraConnectionHandler) TestConnection(c *gin.Context) {
+	if !h.jiraService.IsEnabled() {
+		h.ErrorResponse(c, http.StatusServiceUnavailable, "JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")
+		return
+	}
+
 	connectionID := c.Param("connectionId")
-	
+
 	// Check if user can manage the connection
 	userID := h.getUserID(c)
 	if userID == "" {

--- a/internal/api/jira_connection_handler_test.go
+++ b/internal/api/jira_connection_handler_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/guidewire-oss/fern-platform/internal/domains/integrations"
@@ -226,4 +228,159 @@ func TestJiraConnectionHandler_UnauthenticatedUserIsRejected(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code, "request with no user_id must be rejected")
+}
+
+// ---------------------------------------------------------------------------
+// Disabled-integration ordering: the "JIRA not configured" check must never
+// run ahead of authentication/authorization, or an unauthenticated/forbidden
+// caller learns global server configuration state instead of getting the
+// normal 401/403.
+// ---------------------------------------------------------------------------
+
+// jiraHandlerTestConnRepoWithConnection always resolves FindByID to a single
+// seeded connection, for handlers (Update/UpdateCredentials/TestConnection)
+// that must look up a connection's ProjectID before the permission check.
+type jiraHandlerTestConnRepoWithConnection struct {
+	jiraHandlerTestConnRepo
+	conn *integrations.JiraConnection
+}
+
+func (r *jiraHandlerTestConnRepoWithConnection) FindByID(ctx context.Context, id string) (*integrations.JiraConnection, error) {
+	return r.conn, nil
+}
+
+func buildJiraConnectionHandlerForEnabledState(t *testing.T, permRepo projectsDomain.ProjectPermissionRepository, enabled bool) (*JiraConnectionHandler, *gin.Engine) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	logger, err := logging.NewLogger(&config.LoggingConfig{Level: "error", Format: "json"})
+	require.NoError(t, err)
+
+	conn := integrations.ReconstructJiraConnection(
+		"conn-1", "proj-1", "My JIRA", "https://jira.example.com",
+		integrations.AuthTypeAPIToken, "PROJ", "user@example.com", "encrypted-cred",
+		integrations.ConnectionStatusPending, false, "", nil, time.Now(), time.Now(),
+	)
+	connRepo := &jiraHandlerTestConnRepoWithConnection{conn: conn}
+
+	var key []byte
+	if enabled {
+		key = []byte("0123456789abcdef")
+	}
+	connSvc := integrations.NewJiraConnectionService(connRepo, &jiraHandlerTestJiraClient{}, key, enabled)
+	projSvc := projectsApp.NewProjectService(&jiraHandlerTestProjectRepo{}, permRepo)
+
+	base := NewBaseHandler(logger)
+	handler := NewJiraConnectionHandler(base, connSvc, projSvc)
+	router := gin.New()
+	return handler, router
+}
+
+func TestJiraConnectionHandler_DisabledIntegration_CreateConnection(t *testing.T) {
+	t.Run("unauthenticated request is rejected as unauthorized, not disabled", func(t *testing.T) {
+		handler, router := buildJiraConnectionHandlerForEnabledState(t, newJiraHandlerPermRepo(), false)
+		router.POST("/projects/:projectId/jira-connections", handler.CreateConnection)
+
+		req := httptest.NewRequest("POST", "/projects/proj-1/jira-connections", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"an unauthenticated caller must not learn the JIRA configuration state")
+	})
+
+	t.Run("forbidden user is rejected as forbidden, not disabled", func(t *testing.T) {
+		handler, router := buildJiraConnectionHandlerForEnabledState(t, newJiraHandlerPermRepo(), false) // no permission rows
+		router.Use(productionContextMiddleware("user-1", "user"))
+		router.POST("/projects/:projectId/jira-connections", handler.CreateConnection)
+
+		req := httptest.NewRequest("POST", "/projects/proj-1/jira-connections", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code,
+			"a caller without project access must not learn the JIRA configuration state")
+	})
+
+	t.Run("authorized user gets 503 when JIRA is disabled", func(t *testing.T) {
+		handler, router := buildJiraConnectionHandlerForEnabledState(t, newJiraHandlerPermRepo("user-1"), false)
+		router.Use(productionContextMiddleware("user-1", "user"))
+		router.POST("/projects/:projectId/jira-connections", handler.CreateConnection)
+
+		req := httptest.NewRequest("POST", "/projects/proj-1/jira-connections", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	})
+}
+
+func TestJiraConnectionHandler_DisabledIntegration_ConnectionScopedMutations(t *testing.T) {
+	cases := []struct {
+		name      string
+		method    string
+		routePath string
+		reqPath   string
+		handlerFn func(*JiraConnectionHandler) gin.HandlerFunc
+	}{
+		{
+			name:      "UpdateConnection",
+			method:    "PUT",
+			routePath: "/jira-connections/:connectionId",
+			reqPath:   "/jira-connections/conn-1",
+			handlerFn: func(h *JiraConnectionHandler) gin.HandlerFunc { return h.UpdateConnection },
+		},
+		{
+			name:      "UpdateCredentials",
+			method:    "PUT",
+			routePath: "/jira-connections/:connectionId/credentials",
+			reqPath:   "/jira-connections/conn-1/credentials",
+			handlerFn: func(h *JiraConnectionHandler) gin.HandlerFunc { return h.UpdateCredentials },
+		},
+		{
+			name:      "TestConnection",
+			method:    "POST",
+			routePath: "/jira-connections/:connectionId/test",
+			reqPath:   "/jira-connections/conn-1/test",
+			handlerFn: func(h *JiraConnectionHandler) gin.HandlerFunc { return h.TestConnection },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/unauthenticated returns 401 not 503", func(t *testing.T) {
+			handler, router := buildJiraConnectionHandlerForEnabledState(t, newJiraHandlerPermRepo(), false)
+			router.Handle(tc.method, tc.routePath, tc.handlerFn(handler))
+
+			req := httptest.NewRequest(tc.method, tc.reqPath, strings.NewReader(""))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"an unauthenticated caller must not learn the JIRA configuration state")
+		})
+
+		t.Run(tc.name+"/forbidden returns 403 not 503", func(t *testing.T) {
+			handler, router := buildJiraConnectionHandlerForEnabledState(t, newJiraHandlerPermRepo(), false) // no permission rows
+			router.Use(productionContextMiddleware("user-1", "user"))
+			router.Handle(tc.method, tc.routePath, tc.handlerFn(handler))
+
+			req := httptest.NewRequest(tc.method, tc.reqPath, strings.NewReader(""))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusForbidden, w.Code,
+				"a caller without project access must not learn the JIRA configuration state")
+		})
+
+		t.Run(tc.name+"/authorized gets 503 when JIRA is disabled", func(t *testing.T) {
+			handler, router := buildJiraConnectionHandlerForEnabledState(t, newJiraHandlerPermRepo("user-1"), false)
+			router.Use(productionContextMiddleware("user-1", "user"))
+			router.Handle(tc.method, tc.routePath, tc.handlerFn(handler))
+
+			req := httptest.NewRequest(tc.method, tc.reqPath, strings.NewReader(""))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		})
+	}
 }

--- a/internal/api/jira_connection_handler_test.go
+++ b/internal/api/jira_connection_handler_test.go
@@ -131,7 +131,7 @@ func buildJiraConnectionHandler(t *testing.T, permRepo projectsDomain.ProjectPer
 	require.NoError(t, err)
 
 	key := []byte("0123456789abcdef")
-	connSvc := integrations.NewJiraConnectionService(&jiraHandlerTestConnRepo{}, &jiraHandlerTestJiraClient{}, key)
+	connSvc := integrations.NewJiraConnectionService(&jiraHandlerTestConnRepo{}, &jiraHandlerTestJiraClient{}, key, true)
 	projSvc := projectsApp.NewProjectService(&jiraHandlerTestProjectRepo{}, permRepo)
 
 	base := NewBaseHandler(logger)

--- a/internal/domains/factory.go
+++ b/internal/domains/factory.go
@@ -294,7 +294,7 @@ func (f *DomainFactory) initIntegrationsDomain() {
 
 	// Create coverage service (reuses the same connection repo, JIRA client, and encryption key)
 	tagRepo := tagsInfra.NewGormTagRepository(f.db)
-	f.coverageService = integrations.NewCoverageService(jiraConnRepo, jiraClient, tagRepo, f.jiraFieldMappingService, encryptionKey)
+	f.coverageService = integrations.NewCoverageService(jiraConnRepo, jiraClient, tagRepo, f.jiraFieldMappingService, encryptionKey, keyHex != "")
 }
 
 // GetJiraConnectionService returns the JIRA connection service

--- a/internal/domains/factory.go
+++ b/internal/domains/factory.go
@@ -264,16 +264,20 @@ func (f *DomainFactory) initIntegrationsDomain() {
 	// Create JIRA client
 	jiraClient := integrations.NewDefaultJiraClient()
 
+	var encryptionKey []byte
 	keyHex := os.Getenv("JIRA_ENCRYPTION_KEY")
+
 	if keyHex == "" {
-		panic("JIRA_ENCRYPTION_KEY environment variable is not set; generate with: openssl rand -hex 32")
-	}
-	encryptionKey, err := hex.DecodeString(keyHex)
-	if err != nil {
-		panic(fmt.Sprintf("JIRA_ENCRYPTION_KEY is not valid hex: %v", err))
-	}
-	if len(encryptionKey) != 32 {
-		panic(fmt.Sprintf("JIRA_ENCRYPTION_KEY must decode to exactly 32 bytes, got %d", len(encryptionKey)))
+		f.logger.Warn("JIRA_ENCRYPTION_KEY environment variable is not set; JIRA integration is disabled")
+	} else {
+		var err error
+		encryptionKey, err = hex.DecodeString(keyHex)
+		if err != nil {
+			panic(fmt.Sprintf("JIRA_ENCRYPTION_KEY is not valid hex: %v", err))
+		}
+		if len(encryptionKey) != 32 {
+			panic(fmt.Sprintf("JIRA_ENCRYPTION_KEY must decode to exactly 32 bytes, got %d", len(encryptionKey)))
+		}
 	}
 
 	// Create JIRA connection service
@@ -281,6 +285,7 @@ func (f *DomainFactory) initIntegrationsDomain() {
 		jiraConnRepo,
 		jiraClient,
 		encryptionKey,
+		keyHex != "", // enabled flag: true if encryption key is set
 	)
 
 	// Create JIRA field mapping repo and service

--- a/internal/domains/integrations/coverage_service.go
+++ b/internal/domains/integrations/coverage_service.go
@@ -28,6 +28,7 @@ type CoverageService struct {
 	tagRepo        CoverageTagRepository
 	mappingService fieldMappingLookup
 	encryptionKey  []byte
+	enabled        bool
 }
 
 // NewCoverageService wires up a CoverageService with its dependencies.
@@ -37,6 +38,7 @@ func NewCoverageService(
 	tagRepo CoverageTagRepository,
 	mappingService fieldMappingLookup,
 	encryptionKey []byte,
+	enabled bool,
 ) *CoverageService {
 	return &CoverageService{
 		connRepo:       connRepo,
@@ -44,6 +46,7 @@ func NewCoverageService(
 		tagRepo:        tagRepo,
 		mappingService: mappingService,
 		encryptionKey:  encryptionKey,
+		enabled:        enabled,
 	}
 }
 
@@ -152,6 +155,10 @@ func (s *CoverageService) GetSpecRunsByJiraTag(ctx context.Context, projectID, i
 
 // resolveConnection fetches the active JIRA connection and decrypts its credential.
 func (s *CoverageService) resolveConnection(ctx context.Context, projectID string) (*JiraConnection, string, error) {
+	if !s.enabled {
+		return nil, "", ErrJiraDisabled
+	}
+
 	conns, err := s.connRepo.FindActiveByProjectID(ctx, projectID)
 	if err != nil {
 		return nil, "", fmt.Errorf("coverage: failed to find JIRA connection: %w", err)

--- a/internal/domains/integrations/coverage_service_test.go
+++ b/internal/domains/integrations/coverage_service_test.go
@@ -146,6 +146,7 @@ func TestCoverageService_Build(t *testing.T) {
 			tags,
 			defaultMappingService(),
 			testEncryptionKey,
+			true,
 		)
 	}
 
@@ -408,10 +409,33 @@ func TestCoverageService_Build(t *testing.T) {
 			tags,
 			defaultMappingService(),
 			testEncryptionKey,
+			true,
 		)
 		_, err := svc.Build(ctx, "proj-id", "v1.0")
 		if err == nil {
 			t.Error("expected error when no connection found, got nil")
+		}
+	})
+
+	t.Run("returns ErrJiraDisabled instead of a raw crypto error when disabled", func(t *testing.T) {
+		// A connection created while JIRA was enabled can still exist after
+		// JIRA_ENCRYPTION_KEY is unset. Build must not reach DecryptCredential
+		// with a nil key.
+		jira := &mockCoverageJiraClient{}
+		tags := &mockCoverageTagRepo{data: map[string]tagsdomain.CoverageCount{}}
+		conn := makeTestConnection(t)
+
+		svc := integrations.NewCoverageService(
+			&fixedConnRepo{conn: conn},
+			jira,
+			tags,
+			defaultMappingService(),
+			nil,
+			false,
+		)
+		_, err := svc.Build(ctx, "proj-id", "v1.0")
+		if !errors.Is(err, integrations.ErrJiraDisabled) {
+			t.Errorf("expected ErrJiraDisabled, got: %v", err)
 		}
 	})
 
@@ -426,6 +450,7 @@ func TestCoverageService_Build(t *testing.T) {
 			tags,
 			&mockFieldMappingService{entries: nil}, // no mappings
 			testEncryptionKey,
+			true,
 		)
 		_, err := svc.Build(ctx, "proj-id", "v1.0")
 		if err == nil {
@@ -569,6 +594,7 @@ func TestCoverageService_GetReleasesForProject(t *testing.T) {
 			&mockCoverageTagRepo{},
 			defaultMappingService(),
 			testEncryptionKey,
+			true,
 		)
 		releases, err := svc.GetReleasesForProject(ctx, "proj-id")
 		if err != nil {
@@ -590,10 +616,28 @@ func TestCoverageService_GetReleasesForProject(t *testing.T) {
 			&mockCoverageTagRepo{},
 			defaultMappingService(),
 			testEncryptionKey,
+			true,
 		)
 		_, err := svc.GetReleasesForProject(ctx, "proj-id")
 		if err == nil {
 			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("returns ErrJiraDisabled instead of a raw crypto error when disabled", func(t *testing.T) {
+		jira := &mockCoverageJiraClient{}
+		conn := makeTestConnection(t)
+		svc := integrations.NewCoverageService(
+			&fixedConnRepo{conn: conn},
+			jira,
+			&mockCoverageTagRepo{},
+			defaultMappingService(),
+			nil,
+			false,
+		)
+		_, err := svc.GetReleasesForProject(ctx, "proj-id")
+		if !errors.Is(err, integrations.ErrJiraDisabled) {
+			t.Errorf("expected ErrJiraDisabled, got: %v", err)
 		}
 	})
 }

--- a/internal/domains/integrations/jira_fields_service.go
+++ b/internal/domains/integrations/jira_fields_service.go
@@ -11,6 +11,10 @@ import (
 // connection. The credential is decrypted before being forwarded to the JIRA
 // client; if decryption fails an error is logged and returned.
 func (s *JiraConnectionService) ListJiraFields(ctx context.Context, connectionID string) ([]JiraField, error) {
+	if !s.enabled {
+		return nil, ErrJiraDisabled
+	}
+
 	conn, err := s.repo.FindByID(ctx, connectionID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find connection: %w", err)

--- a/internal/domains/integrations/service.go
+++ b/internal/domains/integrations/service.go
@@ -11,19 +11,30 @@ type JiraConnectionService struct {
 	repo           JiraConnectionRepository
 	jiraClient     JiraClient
 	encryptionKey  []byte
+	enabled        bool
 }
 
 // NewJiraConnectionService creates a new JIRA connection service
-func NewJiraConnectionService(repo JiraConnectionRepository, jiraClient JiraClient, encryptionKey []byte) *JiraConnectionService {
+func NewJiraConnectionService(repo JiraConnectionRepository, jiraClient JiraClient, encryptionKey []byte, enabled bool) *JiraConnectionService {
 	return &JiraConnectionService{
 		repo:          repo,
 		jiraClient:    jiraClient,
 		encryptionKey: encryptionKey,
+		enabled:       enabled,
 	}
+}
+
+// IsEnabled returns whether JIRA integration is enabled
+func (s *JiraConnectionService) IsEnabled() bool {
+	return s.enabled
 }
 
 // CreateConnection creates a new JIRA connection
 func (s *JiraConnectionService) CreateConnection(ctx context.Context, projectID, name, jiraURL string, authType AuthenticationType, projectKey, username, credential, versionFilter string) (*JiraConnection, error) {
+	if !s.enabled {
+		return nil, ErrJiraDisabled
+	}
+
 	// Check if a connection already exists for this project
 	existingConnections, err := s.repo.FindByProjectID(ctx, projectID)
 	if err != nil {
@@ -61,6 +72,10 @@ func (s *JiraConnectionService) CreateConnection(ctx context.Context, projectID,
 
 // UpdateConnection updates an existing JIRA connection
 func (s *JiraConnectionService) UpdateConnection(ctx context.Context, connectionID, name, jiraURL, projectKey, versionFilter string) (*JiraConnection, error) {
+	if !s.enabled {
+		return nil, ErrJiraDisabled
+	}
+
 	// Retrieve the connection
 	conn, err := s.repo.FindByID(ctx, connectionID)
 	if err != nil {
@@ -82,6 +97,10 @@ func (s *JiraConnectionService) UpdateConnection(ctx context.Context, connection
 
 // UpdateCredentials updates the credentials for a JIRA connection
 func (s *JiraConnectionService) UpdateCredentials(ctx context.Context, connectionID string, authType AuthenticationType, username, credential string) (*JiraConnection, error) {
+	if !s.enabled {
+		return nil, ErrJiraDisabled
+	}
+
 	// Retrieve the connection
 	conn, err := s.repo.FindByID(ctx, connectionID)
 	if err != nil {
@@ -110,6 +129,10 @@ func (s *JiraConnectionService) UpdateCredentials(ctx context.Context, connectio
 
 // TestConnection tests a JIRA connection
 func (s *JiraConnectionService) TestConnection(ctx context.Context, connectionID string) error {
+	if !s.enabled {
+		return ErrJiraDisabled
+	}
+
 	// Retrieve the connection
 	conn, err := s.repo.FindByID(ctx, connectionID)
 	if err != nil {

--- a/internal/domains/integrations/service_test.go
+++ b/internal/domains/integrations/service_test.go
@@ -116,7 +116,7 @@ func TestJiraConnectionService_TestConnection_ActivatesOnSuccess(t *testing.T) {
 	key := make([]byte, 32) // zero key is fine for unit tests
 	repo := newMockConnectionRepo()
 	client := &mockJiraClientSvc{}
-	svc := integrations.NewJiraConnectionService(repo, client, key)
+	svc := integrations.NewJiraConnectionService(repo, client, key, true)
 
 	stored := buildStoredConnection(t, key)
 	repo.stored[stored.ID()] = stored
@@ -135,7 +135,7 @@ func TestJiraConnectionService_TestConnection_NotActivatedOnFailure(t *testing.T
 	key := make([]byte, 32)
 	repo := newMockConnectionRepo()
 	client := &mockJiraClientSvc{err: errors.New("auth failed")}
-	svc := integrations.NewJiraConnectionService(repo, client, key)
+	svc := integrations.NewJiraConnectionService(repo, client, key, true)
 
 	stored := buildStoredConnection(t, key)
 	repo.stored[stored.ID()] = stored
@@ -159,7 +159,7 @@ func TestJiraConnectionService_ListJiraFields(t *testing.T) {
 			{ID: "status", Name: "Status", Custom: false},
 		}
 		client := &mockJiraClientSvc{fields: wantFields}
-		svc := integrations.NewJiraConnectionService(repo, client, key)
+		svc := integrations.NewJiraConnectionService(repo, client, key, true)
 
 		stored := buildStoredConnection(t, key)
 		repo.stored[stored.ID()] = stored
@@ -172,7 +172,7 @@ func TestJiraConnectionService_ListJiraFields(t *testing.T) {
 	t.Run("returns error when connection not found", func(t *testing.T) {
 		repo := newMockConnectionRepo()
 		client := &mockJiraClientSvc{}
-		svc := integrations.NewJiraConnectionService(repo, client, key)
+		svc := integrations.NewJiraConnectionService(repo, client, key, true)
 
 		_, err := svc.ListJiraFields(context.Background(), "nonexistent-id")
 		require.Error(t, err)
@@ -182,7 +182,7 @@ func TestJiraConnectionService_ListJiraFields(t *testing.T) {
 		repo := newMockConnectionRepo()
 		clientErr := errors.New("JIRA unavailable")
 		client := &mockJiraClientSvc{err: clientErr}
-		svc := integrations.NewJiraConnectionService(repo, client, key)
+		svc := integrations.NewJiraConnectionService(repo, client, key, true)
 
 		stored := buildStoredConnection(t, key)
 		repo.stored[stored.ID()] = stored
@@ -193,11 +193,71 @@ func TestJiraConnectionService_ListJiraFields(t *testing.T) {
 	})
 }
 
+func TestJiraConnectionService_DisabledIntegration(t *testing.T) {
+	newDisabledService := func() (*integrations.JiraConnectionService, *mockConnectionRepo) {
+		repo := newMockConnectionRepo()
+		client := &mockJiraClientSvc{}
+		svc := integrations.NewJiraConnectionService(repo, client, nil, false)
+		return svc, repo
+	}
+
+	t.Run("IsEnabled reports false", func(t *testing.T) {
+		svc, _ := newDisabledService()
+		assert.False(t, svc.IsEnabled())
+	})
+
+	t.Run("CreateConnection is rejected without touching the repo", func(t *testing.T) {
+		svc, repo := newDisabledService()
+		_, err := svc.CreateConnection(context.Background(), "proj-1", "Test", "https://jira.example.com",
+			integrations.AuthTypeAPIToken, "PROJ", "user@example.com", "token", "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, integrations.ErrJiraDisabled)
+		assert.Empty(t, repo.stored, "repo must not be written to when integration is disabled")
+	})
+
+	t.Run("UpdateConnection is rejected without touching the repo", func(t *testing.T) {
+		svc, repo := newDisabledService()
+		_, err := svc.UpdateConnection(context.Background(), "conn-1", "New Name", "https://jira.example.com", "PROJ", "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, integrations.ErrJiraDisabled)
+		assert.Equal(t, 0, repo.updateCount, "repo must not be written to when integration is disabled")
+	})
+
+	t.Run("UpdateCredentials is rejected without touching the repo", func(t *testing.T) {
+		svc, repo := newDisabledService()
+		_, err := svc.UpdateCredentials(context.Background(), "conn-1", integrations.AuthTypeAPIToken, "user@example.com", "token")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, integrations.ErrJiraDisabled)
+		assert.Equal(t, 0, repo.updateCount, "repo must not be written to when integration is disabled")
+	})
+
+	t.Run("TestConnection is rejected without touching the repo", func(t *testing.T) {
+		svc, repo := newDisabledService()
+		err := svc.TestConnection(context.Background(), "conn-1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, integrations.ErrJiraDisabled)
+		assert.Equal(t, 0, repo.updateCount, "repo must not be written to when integration is disabled")
+	})
+
+	t.Run("enabling integration allows CreateConnection to succeed", func(t *testing.T) {
+		key := make([]byte, 32)
+		repo := newMockConnectionRepo()
+		client := &mockJiraClientSvc{}
+		svc := integrations.NewJiraConnectionService(repo, client, key, true)
+
+		conn, err := svc.CreateConnection(context.Background(), "proj-1", "Test", "https://jira.example.com",
+			integrations.AuthTypeAPIToken, "PROJ", "user@example.com", "token", "")
+		require.NoError(t, err)
+		assert.NotNil(t, conn)
+		assert.True(t, svc.IsEnabled())
+	})
+}
+
 func TestJiraConnectionService_TestConnection_EncryptedCredentialPreservedAfterTest(t *testing.T) {
 	key := make([]byte, 32)
 	repo := newMockConnectionRepo()
 	client := &mockJiraClientSvc{}
-	svc := integrations.NewJiraConnectionService(repo, client, key)
+	svc := integrations.NewJiraConnectionService(repo, client, key, true)
 
 	stored := buildStoredConnection(t, key)
 	originalEncrypted := stored.GetEncryptedCredentialDirect()

--- a/internal/domains/integrations/service_test.go
+++ b/internal/domains/integrations/service_test.go
@@ -191,6 +191,22 @@ func TestJiraConnectionService_ListJiraFields(t *testing.T) {
 		require.Error(t, err)
 		assert.ErrorIs(t, err, clientErr)
 	})
+
+	t.Run("returns ErrJiraDisabled instead of a raw crypto error when disabled", func(t *testing.T) {
+		// A connection created while JIRA was enabled can still exist in the
+		// database after JIRA_ENCRYPTION_KEY is unset. Reading its fields must
+		// not reach DecryptCredential with a nil key.
+		repo := newMockConnectionRepo()
+		client := &mockJiraClientSvc{}
+		svc := integrations.NewJiraConnectionService(repo, client, nil, false)
+
+		stored := buildStoredConnection(t, key)
+		repo.stored[stored.ID()] = stored
+
+		_, err := svc.ListJiraFields(context.Background(), stored.ID())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, integrations.ErrJiraDisabled)
+	})
 }
 
 func TestJiraConnectionService_DisabledIntegration(t *testing.T) {

--- a/internal/domains/integrations/types.go
+++ b/internal/domains/integrations/types.go
@@ -190,3 +190,9 @@ var (
 	ErrUnknownFernField          = errors.New("unknown Fern field")
 	ErrUnknownReductionStrategy  = errors.New("unknown reduction strategy")
 )
+
+// ErrJiraDisabled is returned by JiraConnectionService mutating methods when
+// JIRA_ENCRYPTION_KEY is not configured. Callers (e.g. GraphQL resolvers) can
+// check for it with errors.Is to distinguish "integration not configured"
+// from operation-specific failures (bad credentials, unreachable JIRA, etc).
+var ErrJiraDisabled = errors.New("JIRA integration is not configured; set JIRA_ENCRYPTION_KEY environment variable to enable it")

--- a/internal/reporter/graphql/domain_resolvers_jira_mapping_test.go
+++ b/internal/reporter/graphql/domain_resolvers_jira_mapping_test.go
@@ -298,13 +298,60 @@ func buildDefaultSnapshot(projectID string) *integrations.JiraFieldMappingSnapsh
 }
 
 // ---------------------------------------------------------------------------
+// TestJiraIntegrationEnabledResolver (query)
+// ---------------------------------------------------------------------------
+
+func TestJiraIntegrationEnabledResolver(t *testing.T) {
+	t.Run("reports true when JIRA_ENCRYPTION_KEY is configured", func(t *testing.T) {
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
+
+		resolver := newTestResolverWithJiraMapping(t, nil, connSvc)
+		qr := &queryResolver{resolver}
+
+		result, err := qr.JiraIntegrationEnabled(context.Background())
+
+		require.NoError(t, err)
+		assert.True(t, result)
+	})
+
+	t.Run("reports false when JIRA_ENCRYPTION_KEY is not configured", func(t *testing.T) {
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, nil, false)
+
+		resolver := newTestResolverWithJiraMapping(t, nil, connSvc)
+		qr := &queryResolver{resolver}
+
+		result, err := qr.JiraIntegrationEnabled(context.Background())
+
+		require.NoError(t, err)
+		assert.False(t, result)
+	})
+
+	t.Run("does not require authentication", func(t *testing.T) {
+		// Unlike the connection/mapping resolvers, this is a public capability
+		// flag the UI needs before a user has necessarily authenticated against
+		// a project -- it must not require a user in context.
+		connRepo := &fakeConnRepo{}
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, nil, false)
+
+		resolver := newTestResolverWithJiraMapping(t, nil, connSvc)
+		qr := &queryResolver{resolver}
+
+		_, err := qr.JiraIntegrationEnabled(context.Background())
+
+		assert.NoError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // TestJiraFieldMappingResolver (query)
 // ---------------------------------------------------------------------------
 
 func TestJiraFieldMappingResolver(t *testing.T) {
 	t.Run("non-manager user is denied with authorization error", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingRepo := &fakeMappingRepo{}
 		mappingSvc := integrations.NewJiraFieldMappingService(mappingRepo, connRepo)
 
@@ -320,7 +367,7 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("manager user gets the mapping from service", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 
 		snap := buildDefaultSnapshot("proj-1")
 		// Build a persisted mapping aggregate
@@ -341,7 +388,7 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("admin user gets the mapping from service", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 
 		snap := buildDefaultSnapshot("proj-2")
 		mapping := integrations.ReconstructJiraFieldMapping("proj-2", snap.Entries, "admin-1", snap.CreatedAt, snap.UpdatedAt)
@@ -360,7 +407,7 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("service error is propagated", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingRepo := &fakeMappingRepo{getErr: errors.New("database unavailable")}
 		mappingSvc := integrations.NewJiraFieldMappingService(mappingRepo, connRepo)
 
@@ -375,7 +422,7 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("read-only user is allowed to read the mapping", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		snap := buildDefaultSnapshot("proj-1")
 		mapping := integrations.ReconstructJiraFieldMapping("proj-1", snap.Entries, "reader-1", snap.CreatedAt, snap.UpdatedAt)
 		mappingRepo := &fakeMappingRepo{mapping: mapping}
@@ -393,7 +440,7 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("admin with no permission row is allowed to read the mapping", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		snap := buildDefaultSnapshot("proj-1")
 		mapping := integrations.ReconstructJiraFieldMapping("proj-1", snap.Entries, "admin-no-row", snap.CreatedAt, snap.UpdatedAt)
 		mappingRepo := &fakeMappingRepo{mapping: mapping}
@@ -410,7 +457,7 @@ func TestJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("unauthenticated request is denied", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingRepo := &fakeMappingRepo{}
 		mappingSvc := integrations.NewJiraFieldMappingService(mappingRepo, connRepo)
 
@@ -434,7 +481,7 @@ func TestJiraFieldsResolver(t *testing.T) {
 		// Seed an active connection so the resolver gets past the
 		// connection-lookup and reaches the per-project auth check.
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{buildActiveConnection("proj-1")}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -457,7 +504,7 @@ func TestJiraFieldsResolver(t *testing.T) {
 
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -480,7 +527,7 @@ func TestJiraFieldsResolver(t *testing.T) {
 
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -496,7 +543,7 @@ func TestJiraFieldsResolver(t *testing.T) {
 	t.Run("connection not found returns error", func(t *testing.T) {
 		jiraClient := &fakeJiraClient{}
 		connRepo := &fakeConnRepo{err: errors.New("not found")}
-		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -530,7 +577,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("non-manager user is denied", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -547,7 +594,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 		// reader-1 has PermissionRead but not PermissionWrite; the write boundary must reject them.
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -564,7 +611,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 		// admin-no-row has no permission row but is admin; the bypass must allow them.
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -580,7 +627,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 	t.Run("valid input saves and returns the mapping", func(t *testing.T) {
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -597,7 +644,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 	t.Run("ErrNoJiraConnection maps to appropriate GraphQL error", func(t *testing.T) {
 		// No active connections → Save should fail with ErrNoJiraConnection
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -616,7 +663,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 		// Active connection present but required field is missing
 		activeConn := buildActiveConnection("proj-1")
 		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -641,7 +688,7 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("unauthenticated request is denied", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -655,13 +702,51 @@ func TestSaveJiraFieldMappingResolver(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestTestJiraConnectionResolver (mutation)
+// ---------------------------------------------------------------------------
+
+func TestTestJiraConnectionResolver(t *testing.T) {
+	t.Run("ErrJiraDisabled surfaces as a real GraphQL error, not a swallowed false", func(t *testing.T) {
+		activeConn := buildActiveConnection("proj-1")
+		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
+		// enabled=false: JIRA_ENCRYPTION_KEY not configured.
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, nil, false)
+
+		resolver := newTestResolverWithJiraMapping(t, nil, connSvc)
+		mr := &mutationResolver{resolver}
+
+		result, err := mr.TestJiraConnection(managerCtxForMapping(), "conn-1")
+
+		assert.False(t, result)
+		require.Error(t, err, "a disabled integration must surface as an error, not a silent false")
+		assert.True(t, errors.Is(err, integrations.ErrJiraDisabled) || containsErrMsg(err, "not configured"),
+			"expected ErrJiraDisabled to be surfaced, got: %v", err)
+	})
+
+	t.Run("credential test failure still returns false with no error", func(t *testing.T) {
+		activeConn := buildActiveConnection("proj-1")
+		connRepo := &fakeConnRepo{connections: []*integrations.JiraConnection{activeConn}}
+		jiraClient := &fakeJiraClient{err: errors.New("401 unauthorized")}
+		connSvc := integrations.NewJiraConnectionService(connRepo, jiraClient, testEncryptionKey, true)
+
+		resolver := newTestResolverWithJiraMapping(t, nil, connSvc)
+		mr := &mutationResolver{resolver}
+
+		result, err := mr.TestJiraConnection(managerCtxForMapping(), "conn-1")
+
+		assert.False(t, result)
+		assert.NoError(t, err, "an ordinary credential/test failure must remain a false result, not a GraphQL error")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // TestResetJiraFieldMappingResolver (mutation)
 // ---------------------------------------------------------------------------
 
 func TestResetJiraFieldMappingResolver(t *testing.T) {
 	t.Run("non-manager user is denied", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -676,7 +761,7 @@ func TestResetJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("read-only user is denied the reset mutation", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -691,7 +776,7 @@ func TestResetJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("admin with no permission row is allowed the reset mutation", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -706,7 +791,7 @@ func TestResetJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("manager resets and gets default mapping back", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		// Repo has an existing mapping that will be deleted, returning defaults
 		existingMapping := integrations.ReconstructJiraFieldMapping(
 			"proj-1",
@@ -733,7 +818,7 @@ func TestResetJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("admin resets and returns default mapping", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)
@@ -748,7 +833,7 @@ func TestResetJiraFieldMappingResolver(t *testing.T) {
 
 	t.Run("unauthenticated request is denied", func(t *testing.T) {
 		connRepo := &fakeConnRepo{}
-		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey)
+		connSvc := integrations.NewJiraConnectionService(connRepo, &fakeJiraClient{}, testEncryptionKey, true)
 		mappingSvc := integrations.NewJiraFieldMappingService(&fakeMappingRepo{}, connRepo)
 
 		resolver := newTestResolverWithJiraMapping(t, mappingSvc, connSvc)

--- a/internal/reporter/graphql/generated/generated.go
+++ b/internal/reporter/graphql/generated/generated.go
@@ -265,6 +265,7 @@ type ComplexityRoot struct {
 		JiraFieldMapping        func(childComplexity int, projectID string) int
 		JiraFields              func(childComplexity int, connectionID string) int
 		JiraFixVersions         func(childComplexity int, projectID string) int
+		JiraIntegrationEnabled  func(childComplexity int) int
 		PopularTags             func(childComplexity int, limit *int) int
 		Project                 func(childComplexity int, id string) int
 		ProjectByProjectID      func(childComplexity int, projectID string) int
@@ -546,6 +547,7 @@ type QueryResolver interface {
 	RecentlyAddedFlakyTests(ctx context.Context, projectID *string, days *int, limit *int) ([]*model.FlakyTest, error)
 	JiraConnection(ctx context.Context, id string) (*model.JiraConnection, error)
 	JiraConnections(ctx context.Context, projectID string) ([]*model.JiraConnection, error)
+	JiraIntegrationEnabled(ctx context.Context) (bool, error)
 	JiraFieldMapping(ctx context.Context, projectID string) (*model.JiraFieldMapping, error)
 	JiraFields(ctx context.Context, connectionID string) ([]*model.JiraFieldGql, error)
 	JiraFixVersions(ctx context.Context, projectID string) ([]*model.JiraRelease, error)
@@ -1781,6 +1783,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.JiraFixVersions(childComplexity, args["projectId"].(string)), true
+
+	case "Query.jiraIntegrationEnabled":
+		if e.complexity.Query.JiraIntegrationEnabled == nil {
+			break
+		}
+
+		return e.complexity.Query.JiraIntegrationEnabled(childComplexity), true
 
 	case "Query.popularTags":
 		if e.complexity.Query.PopularTags == nil {
@@ -3685,6 +3694,9 @@ type Query {
   # JIRA Connections
   jiraConnection(id: ID!): JiraConnection
   jiraConnections(projectId: String!): [JiraConnection!]!
+  # True when the server has JIRA_ENCRYPTION_KEY configured. Clients should
+  # use this to gate "Add JIRA Connection" UI before the user opens the form.
+  jiraIntegrationEnabled: Boolean!
 
   # JIRA Field Mapping
   jiraFieldMapping(projectId: String!): JiraFieldMapping!
@@ -13255,6 +13267,50 @@ func (ec *executionContext) fieldContext_Query_jiraConnections(ctx context.Conte
 	if fc.Args, err = ec.field_Query_jiraConnections_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_jiraIntegrationEnabled(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_jiraIntegrationEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().JiraIntegrationEnabled(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_jiraIntegrationEnabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
 	}
 	return fc, nil
 }
@@ -24935,6 +24991,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_jiraConnections(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "jiraIntegrationEnabled":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_jiraIntegrationEnabled(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/reporter/graphql/schema.graphql
+++ b/internal/reporter/graphql/schema.graphql
@@ -586,6 +586,9 @@ type Query {
   # JIRA Connections
   jiraConnection(id: ID!): JiraConnection
   jiraConnections(projectId: String!): [JiraConnection!]!
+  # True when the server has JIRA_ENCRYPTION_KEY configured. Clients should
+  # use this to gate "Add JIRA Connection" UI before the user opens the form.
+  jiraIntegrationEnabled: Boolean!
 
   # JIRA Field Mapping
   jiraFieldMapping(projectId: String!): JiraFieldMapping!

--- a/internal/reporter/graphql/schema.resolvers.go
+++ b/internal/reporter/graphql/schema.resolvers.go
@@ -7,6 +7,7 @@ package graphql
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -396,6 +397,11 @@ func (r *mutationResolver) TestJiraConnection(ctx context.Context, id string) (b
 	r.logger.Infof("Testing JIRA connection %s for project %s", id, connection.ProjectID())
 	if err := r.jiraConnectionService.TestConnection(ctx, id); err != nil {
 		r.logger.Errorf("TestJiraConnection failed: %v", err)
+		if errors.Is(err, integrations.ErrJiraDisabled) {
+			// Not a credential/connectivity failure -- the client needs the real
+			// message, so surface it as an error instead of a silent false.
+			return false, err
+		}
 		return false, nil // Return false but no error so GraphQL returns the boolean
 	}
 
@@ -810,6 +816,11 @@ func (r *queryResolver) JiraConnections(ctx context.Context, projectID string) (
 	}
 
 	return models, nil
+}
+
+// JiraIntegrationEnabled is the resolver for the jiraIntegrationEnabled field.
+func (r *queryResolver) JiraIntegrationEnabled(ctx context.Context) (bool, error) {
+	return r.jiraConnectionService.IsEnabled(), nil
 }
 
 // JiraFieldMapping is the resolver for the jiraFieldMapping field.

--- a/web/index.html
+++ b/web/index.html
@@ -7429,9 +7429,11 @@
             const [testingConnection, setTestingConnection] = useState(null);
             const [showFieldMapping, setShowFieldMapping] = useState(false);
             const [mappingConnection, setMappingConnection] = useState(null);
+            const [jiraIntegrationEnabled, setJiraIntegrationEnabled] = useState(true);
 
             useEffect(() => {
                 fetchConnections();
+                fetchJiraIntegrationEnabled();
             }, [projectId]);
 
             const fetchConnections = async () => {
@@ -7443,6 +7445,18 @@
                     console.error('Failed to fetch JIRA connections:', err);
                 } finally {
                     setLoading(false);
+                }
+            };
+
+            const fetchJiraIntegrationEnabled = async () => {
+                try {
+                    const data = await graphqlClient.query(GRAPHQL_QUERIES.GET_JIRA_INTEGRATION_ENABLED);
+                    setJiraIntegrationEnabled(data.jiraIntegrationEnabled !== false);
+                } catch (err) {
+                    console.error('Failed to fetch JIRA integration status:', err);
+                    // Fail open: don't block the UI on this check failing; the
+                    // save/test calls themselves still enforce the real state.
+                    setJiraIntegrationEnabled(true);
                 }
             };
 
@@ -7575,7 +7589,8 @@
                         </div>
                         <button
                             onClick={handleAddConnection}
-                            disabled={connections.length > 0}
+                            disabled={connections.length > 0 || !jiraIntegrationEnabled}
+                            title={!jiraIntegrationEnabled ? 'JIRA integration is not configured on this server' : undefined}
                             style={{
                                 display: 'flex',
                                 alignItems: 'center',
@@ -7583,18 +7598,36 @@
                                 padding: '0.5rem 1rem',
                                 border: 'none',
                                 borderRadius: 'var(--radius-md)',
-                                background: connections.length > 0 ? 'var(--bg-tertiary)' : 'var(--primary)',
-                                color: connections.length > 0 ? 'var(--text-secondary)' : 'white',
-                                cursor: connections.length > 0 ? 'not-allowed' : 'pointer',
+                                background: (connections.length > 0 || !jiraIntegrationEnabled) ? 'var(--bg-tertiary)' : 'var(--primary)',
+                                color: (connections.length > 0 || !jiraIntegrationEnabled) ? 'var(--text-secondary)' : 'white',
+                                cursor: (connections.length > 0 || !jiraIntegrationEnabled) ? 'not-allowed' : 'pointer',
                                 fontWeight: '600',
                                 fontSize: '0.875rem',
-                                opacity: connections.length > 0 ? 0.6 : 1
+                                opacity: (connections.length > 0 || !jiraIntegrationEnabled) ? 0.6 : 1
                             }}
                         >
                             <i className="fas fa-plus-circle"></i>
                             Add JIRA Connection
                         </button>
                     </div>
+
+                    {!jiraIntegrationEnabled && (
+                        <div style={{
+                            marginBottom: '1.5rem',
+                            padding: '1rem',
+                            background: 'var(--warning)10',
+                            border: '1px solid var(--warning)30',
+                            borderRadius: 'var(--radius-md)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.75rem'
+                        }}>
+                            <i className="fas fa-exclamation-triangle" style={{ color: 'var(--warning)' }}></i>
+                            <span style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>
+                                JIRA integration is not configured on this server. Ask your administrator to set the <code>JIRA_ENCRYPTION_KEY</code> environment variable to enable it.
+                            </span>
+                        </div>
+                    )}
 
                     {connections.length === 0 ? (
                         <div style={{
@@ -7611,14 +7644,17 @@
                             </p>
                             <button
                                 onClick={handleAddConnection}
+                                disabled={!jiraIntegrationEnabled}
+                                title={!jiraIntegrationEnabled ? 'JIRA integration is not configured on this server' : undefined}
                                 style={{
                                     padding: '0.75rem 1.5rem',
                                     border: 'none',
                                     borderRadius: 'var(--radius-md)',
-                                    background: 'var(--primary)',
-                                    color: 'white',
-                                    cursor: 'pointer',
-                                    fontWeight: '600'
+                                    background: !jiraIntegrationEnabled ? 'var(--bg-tertiary)' : 'var(--primary)',
+                                    color: !jiraIntegrationEnabled ? 'var(--text-secondary)' : 'white',
+                                    cursor: !jiraIntegrationEnabled ? 'not-allowed' : 'pointer',
+                                    fontWeight: '600',
+                                    opacity: !jiraIntegrationEnabled ? 0.6 : 1
                                 }}
                             >
                                 Add Your First Connection

--- a/web/index.html
+++ b/web/index.html
@@ -7430,6 +7430,7 @@
             const [showFieldMapping, setShowFieldMapping] = useState(false);
             const [mappingConnection, setMappingConnection] = useState(null);
             const [jiraIntegrationEnabled, setJiraIntegrationEnabled] = useState(true);
+            const [jiraIntegrationEnabledLoaded, setJiraIntegrationEnabledLoaded] = useState(false);
 
             useEffect(() => {
                 fetchConnections();
@@ -7457,6 +7458,8 @@
                     // Fail open: don't block the UI on this check failing; the
                     // save/test calls themselves still enforce the real state.
                     setJiraIntegrationEnabled(true);
+                } finally {
+                    setJiraIntegrationEnabledLoaded(true);
                 }
             };
 
@@ -7562,7 +7565,7 @@
                 );
             };
 
-            if (loading) {
+            if (loading || !jiraIntegrationEnabledLoaded) {
                 return (
                     <div style={{ padding: '2rem', textAlign: 'center' }}>
                         <div className="loading-spinner"></div>

--- a/web/js/graphql-client.js
+++ b/web/js/graphql-client.js
@@ -426,6 +426,12 @@ const QUERIES = {
     `,
     
     // JIRA Connection queries
+    GET_JIRA_INTEGRATION_ENABLED: `
+        query GetJiraIntegrationEnabled {
+            jiraIntegrationEnabled
+        }
+    `,
+
     GET_JIRA_CONNECTIONS: `
         query GetJiraConnections($projectId: String!) {
             jiraConnections(projectId: $projectId) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make JIRA integration optional. When `JIRA_ENCRYPTION_KEY` is unset, the server cleanly disables JIRA and the UI hides/disables connection controls, gated by a new GraphQL capability query.

- **New Features**
  - Made `JIRA_ENCRYPTION_KEY` optional with an enabled flag and `ErrJiraDisabled`; startup now warns and disables JIRA instead of panicking when unset.
  - Guarded REST handlers so auth happens before the disabled check; return clear 503 errors when disabled. Services and coverage logic are gated to avoid decrypting with a nil key.
  - Added GraphQL `jiraIntegrationEnabled` so clients can gate UI; `TestJiraConnection` now surfaces `ErrJiraDisabled` as an error.
  - UI queries `jiraIntegrationEnabled`, disables “Add JIRA Connection” when false, and shows an inline warning.
  - Added a JIRA integration guide and updated README, quick start, k3d, and KubeVela examples to mark the key as optional; expanded tests for disabled state, auth ordering, resolvers, and coverage.

- **Migration**
  - No breaking changes. Existing deployments keep working. To enable JIRA on new installs, set `JIRA_ENCRYPTION_KEY` and restart.

<sup>Written for commit 845a9a0b5dc09649cd86cc0ee9b992b7ca13f6d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

