### PR TITLE
docs: update fern gradle plugin configuration docs (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,13 @@ module.exports = {
 
 ```gradle
 plugins {
-  id 'com.guidewire.fern' version '1.0.0'
+  id("io.github.guidewire-oss.fern-publisher") version "1.1.0"
 }
 
-fern {
-  url = System.getenv('FERN_URL')
-  projectId = System.getenv('FERN_PROJECT_ID')
+fernPublisher {
+  fernUrl.set("FERN_URL")
+  projectId.set("FERN_PROJECT_ID")
+  projectName.set("FERN_PROJECT_NAME")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ plugins {
 }
 
 fernPublisher {
-  fernUrl.set("FERN_URL")
-  projectId.set("FERN_PROJECT_ID")
-  projectName.set("FERN_PROJECT_NAME")
+  fernUrl.set("https://your-fern-instance.example.com")
+  projectId.set("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+  projectName.set("my-project")
 }
 ```
 

--- a/docs/developers/integration-guide.md
+++ b/docs/developers/integration-guide.md
@@ -292,12 +292,13 @@ Add to your `pom.xml`:
 Or for Gradle projects, use our plugin:
 ```gradle
 plugins {
-  id 'com.guidewire.fern' version '1.0.0'
+  id("io.github.guidewire-oss.fern-publisher") version "1.1.0"
 }
 
-fern {
-  url = System.getenv('FERN_URL')
-  projectId = System.getenv('FERN_PROJECT_ID')
+fernPublisher {
+  fernUrl.set("FERN_URL")
+  projectId.set("FERN_PROJECT_ID")
+  projectName.set("FERN_PROJECT_NAME")
 }
 ```
 

--- a/docs/developers/integration-guide.md
+++ b/docs/developers/integration-guide.md
@@ -296,9 +296,9 @@ plugins {
 }
 
 fernPublisher {
-  fernUrl.set("FERN_URL")
-  projectId.set("FERN_PROJECT_ID")
-  projectName.set("FERN_PROJECT_NAME")
+  fernUrl.set("https://your-fern-instance.example.com")
+  projectId.set("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+  projectName.set("my-project")
 }
 ```
 

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -175,9 +175,9 @@ plugins {
 }
 
 fernPublisher {
-    fernUrl.set("FERN_URL")
-    projectId.set("FERN_PROJECT_ID")
-    projectName.set("FERN_PROJECT_NAME")
+    fernUrl.set("https://your-fern-instance.example.com")
+    projectId.set("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+    projectName.set("my-project")
 }
 ```
 [📖 Full Gradle Plugin Documentation](https://github.com/guidewire-oss/fern-junit-gradle-plugin)

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -171,12 +171,13 @@ public class YourTestClass {
 #### **For JUnit with Gradle**
 ```gradle
 plugins {
-    id 'com.guidewire.oss.fern-junit-gradle' version 'latest'
+    id("io.github.guidewire-oss.fern-publisher") version "1.1.0"
 }
 
-fern {
-    projectId = 'YOUR-PROJECT-ID'
-    baseUrl = 'https://your-fern-platform.com'
+fernPublisher {
+    fernUrl.set("FERN_URL")
+    projectId.set("FERN_PROJECT_ID")
+    projectName.set("FERN_PROJECT_NAME")
 }
 ```
 [📖 Full Gradle Plugin Documentation](https://github.com/guidewire-oss/fern-junit-gradle-plugin)


### PR DESCRIPTION
Issue number #202 done

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to use the Gradle plugin `io.github.guidewire-oss.fern-publisher` v1.1.0 with the `fernPublisher` block, replacing `com.guidewire.fern` and `com.guidewire.oss.fern-junit-gradle`. Examples now use `.set(...)` with literal placeholders and include `projectName`.

- **Migration**
  - In `plugins`, replace `com.guidewire.fern` or `com.guidewire.oss.fern-junit-gradle` with `io.github.guidewire-oss.fern-publisher` version `1.1.0`.
  - Replace `fern { ... }` with `fernPublisher { fernUrl.set("https://your-fern-instance.example.com"); projectId.set("6ba7b812-9dad-11d1-80b4-00c04fd430c8"); projectName.set("my-project") }`.

<sup>Written for commit 56e948c86f2ad348aded5830b823879000a01175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

