### PR TITLE
fix(web): proxy /query in the Vite dev server

### DIFF
--- a/Makefile.web
+++ b/Makefile.web
@@ -20,7 +20,7 @@ web-deps: ## Install web dependencies (pnpm install)
 web-codegen: ## Regenerate GraphQL types/hooks from the synced schema
 	cd $(WEB_DIR) && $(PNPM) codegen
 
-web-dev: ## Run Vite dev server (proxies /api, /graphql, /auth to :8080)
+web-dev: ## Run Vite dev server (proxies /api, /graphql, /query, /auth to :8080)
 	cd $(WEB_DIR) && $(PNPM) dev
 
 web-typecheck: ## Type-check the web project

--- a/web-v2/README.md
+++ b/web-v2/README.md
@@ -19,8 +19,9 @@ pnpm install              # first time only
 make web-dev              # or: pnpm dev
 ```
 
-Vite runs on `:5173` and proxies `/api`, `/graphql`, `/auth` to the Go
-server on `:8080`.
+Vite runs on `:5173` and proxies `/api`, `/graphql`, `/query`, `/auth` to
+the Go server on `:8080`. GraphQL requests go to `/query`; `/graphql`
+serves the playground page.
 
 ## Build
 

--- a/web-v2/vite.config.ts
+++ b/web-v2/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     proxy: {
       '/api':     'http://localhost:8080',
       '/graphql': 'http://localhost:8080',
+      '/query':   'http://localhost:8080',
       '/auth':    'http://localhost:8080',
     },
   },


### PR DESCRIPTION
Fixes #224.
**Issue**: While setting up local dev to work on #222, the app loaded but every page showed "Couldn't load projects" with `GraphQL HTTP 404` in the console.
**Fix**: added the `/query` endpoint.
**Verified:** with the rule added, `POST /query` is forwarded to the backend; an unproxied path still 404s from Vite.

**Not fixed here:**
Once requests reach the server, POSTs get a bodyless 403 - `DefaultCORSConfig` allows `localhost:3000/3001/8080` but not `5173`, and release-mode CORS is selected whenever `server.host` is `0.0.0.0`, the value in `config.yaml.example`. GETs pass because browsers omit `Origin` on same-origin GETs but always send it on POSTs. Locally I work around it with `host: "127.0.0.1"` (debug-mode CORS). Can open a follow-up if like `5173` should be allowlisted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxies `/query` in the Vite dev server so GraphQL requests reach the backend. Previously `/query` returned HTTP 404; `/graphql` still serves the playground.

- Updates `vite.config.ts` to proxy `/query` to `http://localhost:8080`; other proxies unchanged.
- Updates `web-v2/README.md` and the `Makefile.web` comment to list `/query` among proxied paths.
- `POST /query` now forwards; non-proxied paths still 404 from Vite.
- CORS: servers started with `host: "0.0.0.0"` may 403 on POST from `:5173`; use `host: "127.0.0.1"` locally or allowlist `5173` in server CORS.

<sup>Written for commit 8c48f71e000be1464e8d66f645522208726e4360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

