### PR TITLE
fix(api): stop test-runs/count from preloading and discarding every run (#138)

### DIFF
--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -196,8 +196,10 @@ func (h *TestRunHandler) listTestRuns(c *gin.Context) {
 func (h *TestRunHandler) countTestRuns(c *gin.Context) {
 	projectID := c.Query("project_id")
 
-	// Get count from domain service using ListTestRuns with limit 0 to get total count only
-	_, totalCount, err := h.testingService.ListTestRuns(c.Request.Context(), projectID, 0, 0)
+	// Count directly- ListTestRuns fetched and discarded every run
+	// in the project just to derive this number, triggering an unbounded
+	// preload of all suites/specs/tags along the way.
+	totalCount, err := h.testingService.CountProjectTestRuns(c.Request.Context(), projectID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -721,8 +721,8 @@ var _ = Describe("TestRunHandler", func() {
 	})
 
 	Describe("countTestRuns", func() {
-		It("should count test runs successfully", func() {
-			testRunRepo.On("GetLatestByProjectID", mock.Anything, "project-123", 0).Return([]*domain.TestRun{}, nil).Once()
+		It("should count test runs successfully without loading the runs themselves", func() {
+			//must not go through GetLatestByProjectID's preload chain
 			testRunRepo.On("CountByProjectID", mock.Anything, "project-123").Return(int64(42), nil).Once()
 
 			req := httptest.NewRequest("GET", "/api/v1/test-runs/count?project_id=project-123", nil)
@@ -737,6 +737,7 @@ var _ = Describe("TestRunHandler", func() {
 			Expect(response["total"]).To(BeNumerically("==", 42))
 
 			testRunRepo.AssertExpectations(GinkgoT())
+			testRunRepo.AssertNotCalled(GinkgoT(), "GetLatestByProjectID", mock.Anything, mock.Anything, mock.Anything)
 		})
 
 		It("should count test runs without project ID", func() {
@@ -755,7 +756,7 @@ var _ = Describe("TestRunHandler", func() {
 		})
 
 		It("should return internal server error when service fails", func() {
-			testRunRepo.On("GetLatestByProjectID", mock.Anything, "project-123", 0).Return(nil, errors.New("database error")).Once()
+			testRunRepo.On("CountByProjectID", mock.Anything, "project-123").Return(int64(0), errors.New("database error")).Once()
 
 			req := httptest.NewRequest("GET", "/api/v1/test-runs/count?project_id=project-123", nil)
 			w := httptest.NewRecorder()

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -199,8 +199,11 @@ func (s *TestRunService) GetProjectTestRuns(ctx context.Context, projectID strin
 	return s.testRunRepo.GetLatestByProjectIDTagsOnly(ctx, projectID, limit)
 }
 
-// CountProjectTestRuns counts total test runs for a project
+// CountProjectTestRuns counts total test runs for a project.
 func (s *TestRunService) CountProjectTestRuns(ctx context.Context, projectID string) (int64, error) {
+	if projectID == "" {
+		return 0, nil
+	}
 	return s.testRunRepo.CountByProjectID(ctx, projectID)
 }
 


### PR DESCRIPTION
Fixes #138.

`GET /api/v1/test-runs/count` derived its total via `ListTestRuns(project, 0, 0)`, which fetches every test run in the project-  with GORM's full 5-level preload (`Tags`, `SuiteRuns`, `SuiteRuns.Tags`, `SuiteRuns.SpecRuns`, `SuiteRuns.SpecRuns.Tags`) then discards the result and returns only the count. So`spec_run_tags ... IN (...)` clause with thousands of IDs comes from here

Now calls `CountProjectTestRuns` (a bare `SELECT count(*)`, no preload at all)

  **Before/after**, for the same project:
  - Before: `spec_run_tags` query with 500+ IDs in the `IN` clause (plus `suite_runs`, `spec_runs`, `tags` etc)
  - Now: one query - `SELECT count(*) FROM test_runs WHERE project_id = ...`
  Output from test
  ```
2026/08/16 23:06:21 /Users/pcp/workspace/fern-platform/internal/domains/testing/infrastructure/gorm_test_run_repo.go:403
[2.366ms] [rows:1] SELECT count(*) FROM "test_runs" WHERE project_id = 'helm-4-004' AND "test_runs"."deleted_at" IS NULL
{"client_ip":"127.0.0.1","latency":"2.470708ms","level":"info","method":"GET","msg":"HTTP request completed","path":"/api/v1/test-runs/count?project_id=helm-4-004","request_id":"ac63174e-e3de-4943-b9b9-04b64c378d36","response_size":12,"status":200,"time":"2026-08-16T23:06:21.074Z","timestamp":"2026-08-16T23:06:21+05:30","user_agent":"curl/8.7.1"}
```

  **Not in scope:** a **linked Copilot comment** on the issue suggested removing the `Preload("SuiteRuns.SpecRuns.Tags")` itself, since a `toDomainSpecRun` helper doesn't include tags. That helper is in `gorm_spec_run_repository.go` (unrelated to this preload)- the converter this preload actually
  feeds, `DatabaseConverter.ConvertSpecRunToDomain`, does populate `SpecRun.Tags` from it. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `GET /api/v1/test-runs/count` from preloading every run just to compute a count. Previously the endpoint called `ListTestRuns(projectID, 0, 0)` (loading suites/specs/tags via deep GORM preloads) and discarded the data; it now counts via `CountProjectTestRuns` → repo `CountByProjectID` (`SELECT count(*) FROM test_runs ...`).

- Response shape is unchanged; DB load and latency drop significantly.
- When `project_id` is empty, we now return 0 without hitting the DB.
- Tests assert the handler does not call `GetLatestByProjectID` and uses `CountByProjectID` instead.
- Not in scope: removing other preloads used by converters elsewhere.

<sup>Written for commit 84e6afa83b3b485dcac18b50a1228fe879f0bb1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

