### PR TITLE
fix(perf): cap unbounded queries in test-run listing, flaky tests etc (#178)

### DIFF
--- a/internal/api/test_run_handler.go
+++ b/internal/api/test_run_handler.go
@@ -18,6 +18,11 @@ import (
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 )
 
+// maxListLimit caps client-supplied ?limit values. Without it,
+// listTestRuns' preload-heavy query and getRecentTestRuns' query both scale
+// with whatever a caller requests, unbounded.
+const maxListLimit = 500
+
 // TestRunHandler handles test run related endpoints
 type TestRunHandler struct {
 	*BaseHandler
@@ -156,6 +161,9 @@ func (h *TestRunHandler) listTestRuns(c *gin.Context) {
 	if limitStr := c.Query("limit"); limitStr != "" {
 		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
 			limit = l
+			if limit > maxListLimit {
+				limit = maxListLimit
+			}
 		} else if l <= 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be greater than 0"})
 			return
@@ -304,6 +312,9 @@ func (h *TestRunHandler) getRecentTestRuns(c *gin.Context) {
 	if limitStr := c.Query("limit"); limitStr != "" {
 		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
 			limit = l
+			if limit > maxListLimit {
+				limit = maxListLimit
+			}
 		} else if l <= 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be greater than 0"})
 			return

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -676,6 +676,27 @@ var _ = Describe("TestRunHandler", func() {
 			testRunRepo.AssertExpectations(GinkgoT())
 		})
 
+		It("should cap an excessive limit rather than as-is", func() {
+			// An uncapped limit triggers the full preload chain across as
+			// many rows as requested.
+			testRuns := []*domain.TestRun{{ID: 1, ProjectID: "project-123", Status: "passed"}}
+			testRunRepo.On("GetLatestByProjectID", mock.Anything, "project-123", 500).Return(testRuns, nil).Once()
+			testRunRepo.On("CountByProjectID", mock.Anything, "project-123").Return(int64(1), nil).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/test-runs?project_id=project-123&limit=100000", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(response["limit"]).To(BeNumerically("==", 500))
+
+			testRunRepo.AssertExpectations(GinkgoT())
+		})
+
 		It("should return bad request for invalid limit", func() {
 			req := httptest.NewRequest("GET", "/api/v1/test-runs?limit=0", nil)
 			w := httptest.NewRecorder()
@@ -963,6 +984,18 @@ var _ = Describe("TestRunHandler", func() {
 			testRunRepo.On("GetLatestByProjectIDTagsOnly", mock.Anything, "project-123", 5).Return(testRuns, nil).Once()
 
 			req := httptest.NewRequest("GET", "/api/v1/test-runs/recent?project_id=project-123&limit=5", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			testRunRepo.AssertExpectations(GinkgoT())
+		})
+
+		It("should cap an excessive limit rather than as-is", func() {
+			testRuns := []*domain.TestRun{{ID: 1, ProjectID: "project-123", Status: "passed"}}
+			testRunRepo.On("GetLatestByProjectIDTagsOnly", mock.Anything, "project-123", 500).Return(testRuns, nil).Once()
+
+			req := httptest.NewRequest("GET", "/api/v1/test-runs/recent?project_id=project-123&limit=100000", nil)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 

--- a/internal/domains/analytics/infrastructure/gorm_flaky_repository.go
+++ b/internal/domains/analytics/infrastructure/gorm_flaky_repository.go
@@ -12,6 +12,10 @@ import (
 
 // maxFlakyTestsPerProject caps FindFlakyTestsByProject
 const maxFlakyTestsPerProject = 500
+// maxHistoryRowsPerTest caps GetTestRunHistory. Separate from
+// maxFlakyTestsPerProject since the two bound different things and
+// share a value today.
+const maxHistoryRowsPerTest = 500
 
 // GormFlakyDetectionRepository implements FlakyDetectionRepository using GORM
 type GormFlakyDetectionRepository struct {
@@ -117,8 +121,8 @@ func (r *GormFlakyDetectionRepository) SaveTestRunAnalysis(ctx context.Context, 
 // GetTestRunHistory retrieves test execution history for a specific test
 func (r *GormFlakyDetectionRepository) GetTestRunHistory(ctx context.Context, projectID string, testName string, since time.Time) ([]domain.TestExecutionResult, error) {
 	// Use a raw query to get all the needed data in one query
-	query := `
-		SELECT 
+	query := fmt.Sprintf(`
+		SELECT
 			sr.id as spec_run_id,
 			sr.name as test_name,
 			sr.status,
@@ -134,8 +138,8 @@ func (r *GormFlakyDetectionRepository) GetTestRunHistory(ctx context.Context, pr
 		JOIN test_runs tr ON tr.id = sur.test_run_id
 		WHERE tr.project_id = ? AND sr.name = ? AND tr.created_at >= ?
 		ORDER BY tr.created_at DESC
-		LIMIT 500
-	`
+		LIMIT %d
+	`, maxHistoryRowsPerTest)
 
 	rows, err := r.db.WithContext(ctx).Raw(query, projectID, testName, since).Rows()
 	if err != nil {

--- a/internal/domains/analytics/infrastructure/gorm_flaky_repository.go
+++ b/internal/domains/analytics/infrastructure/gorm_flaky_repository.go
@@ -10,6 +10,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// maxFlakyTestsPerProject caps FindFlakyTestsByProject
+const maxFlakyTestsPerProject = 500
+
 // GormFlakyDetectionRepository implements FlakyDetectionRepository using GORM
 type GormFlakyDetectionRepository struct {
 	db *gorm.DB
@@ -68,7 +71,9 @@ func (r *GormFlakyDetectionRepository) FindFlakyTestsByProject(ctx context.Conte
 		query = query.Where("status = ?", string(status))
 	}
 
-	if err := query.Order("flake_score DESC").Find(&dbFlakyTests).Error; err != nil {
+	// capped so an active project's flake list can't grow
+	// unbounded; ordering by flake_score DESC keeps the worst offenders.
+	if err := query.Order("flake_score DESC").Limit(maxFlakyTestsPerProject).Find(&dbFlakyTests).Error; err != nil {
 		return nil, fmt.Errorf("failed to find flaky tests: %w", err)
 	}
 
@@ -129,6 +134,7 @@ func (r *GormFlakyDetectionRepository) GetTestRunHistory(ctx context.Context, pr
 		JOIN test_runs tr ON tr.id = sur.test_run_id
 		WHERE tr.project_id = ? AND sr.name = ? AND tr.created_at >= ?
 		ORDER BY tr.created_at DESC
+		LIMIT 500
 	`
 
 	rows, err := r.db.WithContext(ctx).Raw(query, projectID, testName, since).Rows()

--- a/internal/domains/analytics/infrastructure/gorm_flaky_repository_test.go
+++ b/internal/domains/analytics/infrastructure/gorm_flaky_repository_test.go
@@ -57,6 +57,7 @@ func TestGormFlakyDetectionRepository_FindFlakyTestsByProject_HasLimit(t *testin
 
 	rows := sqlmock.NewRows([]string{"id", "project_id", "status", "flake_rate"})
 	mock.ExpectQuery(`SELECT \* FROM "flaky_tests" WHERE project_id = \$1 AND status = \$2 AND "flaky_tests"\."deleted_at" IS NULL ORDER BY flake_score DESC LIMIT \$3`).
+		WithArgs("project-123", string(domain.StatusActive), 500).
 		WillReturnRows(rows)
 
 	_, err := repo.FindFlakyTestsByProject(context.Background(), "project-123", domain.StatusActive)

--- a/internal/domains/analytics/infrastructure/gorm_flaky_repository_test.go
+++ b/internal/domains/analytics/infrastructure/gorm_flaky_repository_test.go
@@ -1,0 +1,65 @@
+package infrastructure_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/guidewire-oss/fern-platform/internal/domains/analytics/domain"
+	"github.com/guidewire-oss/fern-platform/internal/domains/analytics/infrastructure"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func setupFlakyMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *gorm.DB) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{})
+	require.NoError(t, err)
+
+	return db, mock, gormDB
+}
+
+// GetTestRunHistory's raw query must not load a test's entire execution
+// history unbounded.
+func TestGormFlakyDetectionRepository_GetTestRunHistory_HasLimit(t *testing.T) {
+	db, mock, gormDB := setupFlakyMockDB(t)
+	defer db.Close()
+
+	repo := infrastructure.NewGormFlakyDetectionRepository(gormDB)
+
+	rows := sqlmock.NewRows([]string{
+		"spec_run_id", "test_name", "status", "duration", "failure_message",
+		"created_at", "suite_name", "test_run_id", "git_branch", "git_commit",
+	})
+	mock.ExpectQuery(`LIMIT 500`).
+		WithArgs("project-123", "TestFoo", sqlmock.AnyArg()).
+		WillReturnRows(rows)
+
+	_, err := repo.GetTestRunHistory(context.Background(), "project-123", "TestFoo", time.Now())
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// FindFlakyTestsByProject must not load every flaky test for a project
+// unbounded.
+func TestGormFlakyDetectionRepository_FindFlakyTestsByProject_HasLimit(t *testing.T) {
+	db, mock, gormDB := setupFlakyMockDB(t)
+	defer db.Close()
+
+	repo := infrastructure.NewGormFlakyDetectionRepository(gormDB)
+
+	rows := sqlmock.NewRows([]string{"id", "project_id", "status", "flake_rate"})
+	mock.ExpectQuery(`SELECT \* FROM "flaky_tests" WHERE project_id = \$1 AND status = \$2 AND "flaky_tests"\."deleted_at" IS NULL ORDER BY flake_score DESC LIMIT \$3`).
+		WillReturnRows(rows)
+
+	_, err := repo.FindFlakyTestsByProject(context.Background(), "project-123", domain.StatusActive)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/domains/projects/infrastructure/gorm_project_repository.go
+++ b/internal/domains/projects/infrastructure/gorm_project_repository.go
@@ -77,10 +77,14 @@ func (r *GormProjectRepository) FindByProjectID(ctx context.Context, projectID d
 	return r.toDomainModel(&dbProject)
 }
 
+// maxProjectsPerTeam caps FindByTeam so a team with an unusually large
+// number of projects cannot return them all unbounded.
+const maxProjectsPerTeam = 1000
+
 // FindByTeam retrieves all projects for a team
 func (r *GormProjectRepository) FindByTeam(ctx context.Context, team domain.Team) ([]*domain.Project, error) {
 	var dbProjects []database.ProjectDetails
-	if err := r.db.WithContext(ctx).Where("team = ?", string(team)).Find(&dbProjects).Error; err != nil {
+	if err := r.db.WithContext(ctx).Where("team = ?", string(team)).Limit(maxProjectsPerTeam).Find(&dbProjects).Error; err != nil {
 		return nil, fmt.Errorf("failed to find projects by team: %w", err)
 	}
 

--- a/internal/domains/projects/infrastructure/gorm_project_repository_test.go
+++ b/internal/domains/projects/infrastructure/gorm_project_repository_test.go
@@ -52,6 +52,25 @@ func TestGormProjectRepository_Delete_CascadeDelete(t *testing.T) {
 	})
 }
 
+func TestGormProjectRepository_FindByTeam_HasLimit(t *testing.T) {
+	t.Run("should cap the number of projects returned", func(t *testing.T) {
+		db, mock, gormDB := setupMockDB(t)
+		defer db.Close()
+
+		repo := infrastructure.NewGormProjectRepository(gormDB)
+
+		rows := sqlmock.NewRows([]string{"id", "project_id", "name", "team"})
+		mock.ExpectQuery(`SELECT \* FROM "project_details" WHERE team = \$1 AND "project_details"\."deleted_at" IS NULL LIMIT \$2`).
+			WithArgs("team-a", sqlmock.AnyArg()).
+			WillReturnRows(rows)
+
+		_, err := repo.FindByTeam(context.Background(), domain.Team("team-a"))
+
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 // Integration test to verify cascade delete works with real foreign key
 // This test would need a test database to run properly
 func TestProjectDeletion_Integration(t *testing.T) {

--- a/internal/domains/projects/infrastructure/gorm_project_repository_test.go
+++ b/internal/domains/projects/infrastructure/gorm_project_repository_test.go
@@ -61,7 +61,7 @@ func TestGormProjectRepository_FindByTeam_HasLimit(t *testing.T) {
 
 		rows := sqlmock.NewRows([]string{"id", "project_id", "name", "team"})
 		mock.ExpectQuery(`SELECT \* FROM "project_details" WHERE team = \$1 AND "project_details"\."deleted_at" IS NULL LIMIT \$2`).
-			WithArgs("team-a", sqlmock.AnyArg()).
+			WithArgs("team-a", 1000).
 			WillReturnRows(rows)
 
 		_, err := repo.FindByTeam(context.Background(), domain.Team("team-a"))
@@ -121,8 +121,8 @@ func TestGormProjectRepository_FindByID_NotFound(t *testing.T) {
 		projectID := uint(123)
 
 		mock.ExpectQuery(`SELECT .* FROM "project_details"`).
-    		WithArgs(projectID, sqlmock.AnyArg()).
-    		WillReturnError(gorm.ErrRecordNotFound)
+			WithArgs(projectID, sqlmock.AnyArg()).
+			WillReturnError(gorm.ErrRecordNotFound)
 
 		project, err := repo.FindByID(ctx, projectID)
 


### PR DESCRIPTION
Fixes #178 partially (items 3, 4, 6, 8).

Four unbounded queries, capped:

- `listTestRuns` / `getRecentTestRuns`: `?limit=` had no max - a caller could request `?limit=100000` and trigger the full preload chain across that many rows. Capped at 500.
- `FindFlakyTestsByProject`: no limit on a project's flaky-test list. Capped at 500, ordered by flake_score DESC
- `GetTestRunHistory`: raw SQL had no LIMIT, loading a test's entire execution history. Added `LIMIT 500`.
- `FindByTeam`: no limit at all. Capped at 1000 - no signature change, since its only caller (`ListTeamProjects`) has no callers of its own; not worth a full pagination API for unreachable code.

### Testing and verification
**Also verified manually:** stashed just the production changes, keeping the new tests in place, to confirm they actually catch the bug rather than just pass by construction.

`git stash push -- internal/api/test_run_handler.go internal/domains/analytics/infrastructure/gorm_flaky_repository.go
  internal/domains/projects/infrastructure/gorm_project_repository.go `
 ` go test ./internal/api/... ./internal/domains/analytics/infrastructure/... ./internal/domains/projects/infrastructure/... -v`

Before- 5 tests failed across all 3 packages -the two `?limit=` cap tests, both flaky-repo LIMIT tests, and the `FindByTeam`   test.
Now- `git stash pop` restored the fixes and all 5 went green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps unbounded queries for test-run listing, flaky-test retrieval, test run history, and project-by-team lookups to prevent slow scans and excessive preloads. Previously these returned unbounded result sets; now fixed limits stabilize performance and memory.

- listTestRuns and getRecentTestRuns: `?limit` capped at 500 via maxListLimit. If `limit > 500`, only 500 are returned; listTestRuns reports `limit: 500` in the response.
- FindFlakyTestsByProject: capped at 500 via maxFlakyTestsPerProject, ordered by `flake_score DESC` to surface the worst offenders first.
- GetTestRunHistory: raw SQL adds `LIMIT 500` via maxHistoryRowsPerTest, returning the most recent 500 by `created_at DESC`. Cap constant is now decoupled from the per-project flaky limit.
- FindByTeam: capped at 1000 via maxProjectsPerTeam. No signature changes; only the result size is bounded.
- Tests assert concrete `LIMIT` clauses and ordering across handlers and repositories.

<sup>Written for commit a35428eaea9090993aefcaea2e3409fd7a72f75a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

