### PR TITLE
fix: widen spec/suite/tag name columns to text and truncate oversized names on ingest instead of rejecting the batch #230

### DIFF
--- a/internal/api/tag_handler.go
+++ b/internal/api/tag_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	tagsApp "github.com/guidewire-oss/fern-platform/internal/domains/tags/application"
 	tagsDomain "github.com/guidewire-oss/fern-platform/internal/domains/tags/domain"
+	testingDomain "github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 )
 
@@ -68,8 +69,17 @@ func ProcessTestRunTags(c context.Context, tagService *tagsApp.TagService, req *
 func processTagList(c context.Context, tagService *tagsApp.TagService, tags []Tag) ([]Tag, error) {
 	result := make([]Tag, 0, len(tags))
 	for _, t := range tags {
+		// Bound the name before it ever reaches GetOrCreateTag: tags.name
+		// carries a unique index, so an oversized tag value can crash the
+		// insert here the same way spec_name/suite_name did before issue
+		// #230's fix. Truncating up front (rather than after Save) also
+		// means the FindByName lookups inside GetOrCreateTag consistently
+		// see the same, already-normalized name -- no risk of the lookup
+		// missing the row it just wrote.
+		name := testingDomain.TruncateName(t.Name)
+
 		// Use the tag service to get or create the tag
-		domainTag, err := tagService.GetOrCreateTag(c, t.Name)
+		domainTag, err := tagService.GetOrCreateTag(c, name)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/api/tag_handler_test.go
+++ b/internal/api/tag_handler_test.go
@@ -19,6 +19,7 @@ import (
 
 	tagsApp "github.com/guidewire-oss/fern-platform/internal/domains/tags/application"
 	tagsDomain "github.com/guidewire-oss/fern-platform/internal/domains/tags/domain"
+	testingDomain "github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
 	"github.com/guidewire-oss/fern-platform/pkg/logging"
 )
 
@@ -182,6 +183,25 @@ var _ = Describe("TagHandler & tag processing", func() {
 			Expect(len(req.SuiteRuns)).To(Equal(1))
 			Expect(req.SuiteRuns[0].Tags[0].ID).NotTo(Equal(uint64(0)))
 			Expect(req.SuiteRuns[0].SpecRuns[0].Tags[0].ID).NotTo(Equal(uint64(0)))
+		})
+
+		It("truncates an oversized tag name before it reaches GetOrCreateTag", func() {
+			// tags.name carries a unique index, so an oversized value can
+			// crash the insert the same way spec_name/suite_name did
+			// before issue #230's fix. The name must be bounded here,
+			// before GetOrCreateTag's FindByName/Save/FindByName cycle
+			// runs, so every lookup in that cycle consistently sees the
+			// same (already-truncated) value.
+			longName := strings.Repeat("a", testingDomain.MaxNameLengthBytes+256)
+			req := &TestRunRequest{
+				Tags: []Tag{{Name: longName}},
+			}
+
+			err := ProcessTestRunTags(context.Background(), svc, req)
+			Expect(err).To(BeNil())
+			Expect(len(req.Tags)).To(Equal(1))
+			Expect(len(req.Tags[0].Name)).To(Equal(testingDomain.MaxNameLengthBytes))
+			Expect(req.Tags[0].Name).To(HaveSuffix(testingDomain.TruncationMarker))
 		})
 
 		It("returns error when repository fails during GetOrCreateTag", func() {

--- a/internal/api/test_run_handler_test.go
+++ b/internal/api/test_run_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -1573,7 +1574,9 @@ var _ = Describe("TestRunHandler", func() {
 				Expect(w.Code).To(Equal(http.StatusBadRequest))
 			})
 
-			It("should return bad request when test run validation fails", func() {
+			It("should truncate an oversized spec name instead of rejecting the whole submission", func() {
+				// A single overlong spec name must not take down an entire
+				// run's results -- https://github.com/guidewire-oss/fern-platform/issues/230.
 				req := TestRunRequest{
 					TestProjectID: "project-123",
 					SuiteRuns: []SuiteRun{
@@ -1581,7 +1584,7 @@ var _ = Describe("TestRunHandler", func() {
 							SuiteName: "Suite 1",
 							SpecRuns: []SpecRun{
 								{
-									SpecDescription: string(make([]byte, 300)), // simulate long spec name
+									SpecDescription: strings.Repeat("a", domain.MaxNameLengthBytes+300),
 									Status:          "passed",
 								},
 							},
@@ -1591,19 +1594,18 @@ var _ = Describe("TestRunHandler", func() {
 
 				jsonBody, _ := json.Marshal(req)
 
+				testRunRepo.On("Create", mock.Anything, mock.MatchedBy(func(tr *domain.TestRun) bool {
+					name := tr.SuiteRuns[0].SpecRuns[0].Name
+					return len(name) == domain.MaxNameLengthBytes &&
+						strings.HasSuffix(name, domain.TruncationMarker)
+				})).Return(nil)
+
 				httpReq := httptest.NewRequest("POST", "/api/v1/test-runs", bytes.NewBuffer(jsonBody))
 				httpReq.Header.Set("Content-Type", "application/json")
 				w := httptest.NewRecorder()
 				publicRouter.ServeHTTP(w, httpReq)
 
-				Expect(w.Code).To(Equal(http.StatusBadRequest))
-
-				var response map[string]interface{}
-				err := json.Unmarshal(w.Body.Bytes(), &response)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(response["error"]).To(ContainSubstring("invalid test run"))
-				testRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+				Expect(w.Code).To(Equal(http.StatusCreated))
 			})
 		})
 

--- a/internal/domains/testing/application/test_run_service.go
+++ b/internal/domains/testing/application/test_run_service.go
@@ -6,15 +6,10 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/guidewire-oss/fern-platform/internal/domains/testing/domain"
 	"github.com/guidewire-oss/fern-platform/pkg/database"
 	"gorm.io/gorm"
-)
-
-const (
-	MaxSpecNameLength = 255
 )
 
 // ErrNotFound is returned when a resource is not found or parent-child validation fails
@@ -41,26 +36,23 @@ func NewTestRunService(
 	}
 }
 
-// ValidateTestRun does validation of test run details
+// ValidateTestRun validates test run details and normalizes names that
+// would otherwise be too long to store. Oversized suite/spec names are
+// truncated in place (see truncateName) rather than rejected, so a
+// single overlong name can't fail the whole test run submission.
 func ValidateTestRun(testRun *domain.TestRun) error {
 	if testRun == nil {
 		return fmt.Errorf("testRun cannot be nil")
 	}
 
-	for _, suite := range testRun.SuiteRuns {
+	for i := range testRun.SuiteRuns {
+		suite := &testRun.SuiteRuns[i]
+		suite.Name = domain.TruncateName(suite.Name)
 		for _, spec := range suite.SpecRuns {
 			if spec == nil {
 				continue
 			}
-			if utf8.RuneCountInString(spec.Name) > MaxSpecNameLength {
-				return fmt.Errorf(
-					"%w: spec name exceeds %d characters (suite: %s, spec: %s)",
-					domain.ErrInvalidTestRun,
-					MaxSpecNameLength,
-					suite.Name,
-					spec.Name,
-				)
-			}
+			spec.Name = domain.TruncateName(spec.Name)
 		}
 	}
 
@@ -155,6 +147,8 @@ func (s *TestRunService) AddSuiteRun(ctx context.Context, testRunID uint, suiteR
 		return fmt.Errorf("suite run test ID mismatch")
 	}
 
+	suiteRun.Name = domain.TruncateName(suiteRun.Name)
+
 	// Create the suite run
 	if err := s.suiteRunRepo.Create(ctx, suiteRun); err != nil {
 		return fmt.Errorf("failed to create suite run: %w", err)
@@ -169,6 +163,8 @@ func (s *TestRunService) AddSpecRun(ctx context.Context, suiteRunID uint, specRu
 	if specRun.SuiteRunID != suiteRunID {
 		return fmt.Errorf("spec run suite ID mismatch")
 	}
+
+	specRun.Name = domain.TruncateName(specRun.Name)
 
 	// Create the spec run
 	if err := s.specRunRepo.Create(ctx, specRun); err != nil {
@@ -381,6 +377,8 @@ func (s *TestRunService) CreateSuiteRun(ctx context.Context, suiteRun *domain.Su
 		suiteRun.StartTime = time.Now()
 	}
 
+	suiteRun.Name = domain.TruncateName(suiteRun.Name)
+
 	return s.suiteRunRepo.Create(ctx, suiteRun)
 }
 
@@ -406,6 +404,8 @@ func (s *TestRunService) CreateSpecRun(ctx context.Context, specRun *domain.Spec
 			specRun.Duration = specRun.EndTime.Sub(specRun.StartTime)
 		}
 	}
+
+	specRun.Name = domain.TruncateName(specRun.Name)
 
 	return s.specRunRepo.Create(ctx, specRun)
 }

--- a/internal/domains/testing/application/test_run_service_test.go
+++ b/internal/domains/testing/application/test_run_service_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -374,8 +375,10 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			mockTestRunRepo.AssertExpectations(GinkgoT())
 		})
 
-		It("should return error when one of the spec name exceeds max length", func() {
-			longName := strings.Repeat("a", 256)
+		It("should truncate (not reject) a spec name that exceeds max length", func() {
+			// A single oversized name must not fail the whole submission --
+			// https://github.com/guidewire-oss/fern-platform/issues/230.
+			longName := strings.Repeat("a", domain.MaxNameLengthBytes+256)
 
 			testRun := &domain.TestRun{
 				ProjectID: "proj-123",
@@ -391,19 +394,30 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 				},
 			}
 
+			mockTestRunRepo.On("Create", ctx, mock.MatchedBy(func(tr *domain.TestRun) bool {
+				name := tr.SuiteRuns[0].SpecRuns[0].Name
+				return len(name) == domain.MaxNameLengthBytes &&
+					strings.HasSuffix(name, domain.TruncationMarker)
+			})).Return(nil)
+
 			result, alreadyExisted, err := service.CreateTestRun(ctx, testRun)
 
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid test run"))
-			Expect(result).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
 			Expect(alreadyExisted).To(BeFalse())
 
-			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+			mockTestRunRepo.AssertExpectations(GinkgoT())
 		})
 
-		It("should validate spec name length using rune count (unicode)", func() {
-			// each "你" is 1 rune but 3 bytes
-			longName := strings.Repeat("你", 256)
+		It("should truncate using byte length while preserving valid UTF-8 (unicode)", func() {
+			// "你" is 1 rune but 3 bytes -- truncating at a fixed byte
+			// count risks slicing a multi-byte rune in half unless the
+			// cut point is backed off to a rune boundary. The exact kept
+			// length can therefore land a couple bytes short of
+			// MaxNameLengthBytes (whatever it takes to land on a
+			// boundary); what must hold is that it never exceeds the
+			// budget and never produces invalid UTF-8.
+			longName := strings.Repeat("你", domain.MaxNameLengthBytes+256)
 
 			testRun := &domain.TestRun{
 				ProjectID: "proj-123",
@@ -419,14 +433,20 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 				},
 			}
 
+			mockTestRunRepo.On("Create", ctx, mock.MatchedBy(func(tr *domain.TestRun) bool {
+				name := tr.SuiteRuns[0].SpecRuns[0].Name
+				return len(name) <= domain.MaxNameLengthBytes &&
+					utf8.ValidString(name) &&
+					strings.HasSuffix(name, domain.TruncationMarker)
+			})).Return(nil)
+
 			result, alreadyExisted, err := service.CreateTestRun(ctx, testRun)
 
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid test run"))
-			Expect(result).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
 			Expect(alreadyExisted).To(BeFalse())
 
-			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
+			mockTestRunRepo.AssertExpectations(GinkgoT())
 		})
 
 		It("should ignore nil spec runs during validation", func() {
@@ -724,6 +744,25 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			Expect(err.Error()).To(ContainSubstring("test ID mismatch"))
 		})
 
+		It("should truncate an oversized name instead of failing (append-to-existing-run path)", func() {
+			// AddSuiteRun is the path used when suites are appended to a test
+			// run that already exists -- it must guard name length itself,
+			// it can't rely on CreateTestRun's validation having run.
+			suiteRun := &domain.SuiteRun{
+				TestRunID: 1,
+				Name:      strings.Repeat("a", domain.MaxNameLengthBytes+256),
+			}
+
+			mockSuiteRepo.On("Create", ctx, mock.MatchedBy(func(s *domain.SuiteRun) bool {
+				return len(s.Name) == domain.MaxNameLengthBytes
+			})).Return(nil)
+
+			err := service.AddSuiteRun(ctx, 1, suiteRun)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockSuiteRepo.AssertExpectations(GinkgoT())
+		})
+
 		It("should return error when repository fails", func() {
 			suiteRun := &domain.SuiteRun{
 				TestRunID: 1,
@@ -772,6 +811,30 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			err := service.AddSpecRun(ctx, 1, specRun)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("suite ID mismatch"))
+		})
+
+		It("should truncate an oversized name instead of failing (append-to-existing-run path)", func() {
+			specRun := &domain.SpecRun{
+				SuiteRunID: 1,
+				Name:       strings.Repeat("a", domain.MaxNameLengthBytes+256),
+			}
+			suiteRun := &domain.SuiteRun{
+				ID:        1,
+				Name:      "Suite",
+				StartTime: time.Now(),
+			}
+
+			mockSpecRepo.On("Create", ctx, mock.MatchedBy(func(s *domain.SpecRun) bool {
+				return len(s.Name) == domain.MaxNameLengthBytes
+			})).Return(nil)
+			mockSpecRepo.On("FindBySuiteRunID", ctx, uint(1)).Return([]*domain.SpecRun{specRun}, nil)
+			mockSuiteRepo.On("GetByID", ctx, uint(1)).Return(suiteRun, nil)
+			mockSuiteRepo.On("Update", ctx, mock.Anything).Return(nil)
+
+			err := service.AddSpecRun(ctx, 1, specRun)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockSpecRepo.AssertExpectations(GinkgoT())
 		})
 
 		It("should return error when repository fails", func() {
@@ -863,8 +926,8 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
 		})
 
-		It("should return error when spec name exceeds max length in CreateTestRunWithSuites", func() {
-			longName := strings.Repeat("a", 256)
+		It("should truncate (not reject) a spec name that exceeds max length in CreateTestRunWithSuites", func() {
+			longName := strings.Repeat("a", domain.MaxNameLengthBytes+256)
 
 			testRun := &domain.TestRun{
 				ProjectID: "proj-123",
@@ -885,16 +948,20 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 
 			mockTestRunRepo.On("Create", ctx, testRun).Return(nil)
 			mockSuiteRepo.On("Create", ctx, mock.Anything).Return(nil)
+			mockSpecRepo.On("CreateBatch", ctx, mock.MatchedBy(func(specs []*domain.SpecRun) bool {
+				return len(specs) == 1 && len(specs[0].Name) == domain.MaxNameLengthBytes
+			})).Return(nil)
+			mockTestRunRepo.On("GetByID", ctx, mock.Anything).Return(testRun, nil)
+			mockSuiteRepo.On("FindByTestRunID", ctx, mock.Anything).Return([]*domain.SuiteRun{}, nil)
+			mockTestRunRepo.On("Update", ctx, mock.Anything).Return(nil)
 
 			err := service.CreateTestRunWithSuites(ctx, testRun, suites)
 
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid test run"))
+			Expect(err).NotTo(HaveOccurred())
 
-			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
-			mockTestRunRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
-			mockSuiteRepo.AssertNotCalled(GinkgoT(), "Create", mock.Anything, mock.Anything)
-			mockSpecRepo.AssertNotCalled(GinkgoT(), "CreateBatch", mock.Anything, mock.Anything)
+			mockTestRunRepo.AssertExpectations(GinkgoT())
+			mockSuiteRepo.AssertExpectations(GinkgoT())
+			mockSpecRepo.AssertExpectations(GinkgoT())
 		})
 
 		It("should return error when test run creation fails", func() {
@@ -949,6 +1016,22 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			err := service.CreateSuiteRun(ctx, suiteRun)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should truncate an oversized name instead of failing", func() {
+			suiteRun := &domain.SuiteRun{
+				TestRunID: 1,
+				Name:      strings.Repeat("a", domain.MaxNameLengthBytes+256),
+			}
+
+			mockSuiteRepo.On("Create", ctx, mock.MatchedBy(func(s *domain.SuiteRun) bool {
+				return len(s.Name) == domain.MaxNameLengthBytes
+			})).Return(nil)
+
+			err := service.CreateSuiteRun(ctx, suiteRun)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockSuiteRepo.AssertExpectations(GinkgoT())
+		})
 	})
 
 	Describe("CreateSpecRun", func() {
@@ -976,6 +1059,22 @@ var _ = Describe("TestRunService", Label("unit", "application", "testing"), func
 			err := service.CreateSpecRun(ctx, specRun)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("suite run ID is required"))
+		})
+
+		It("should truncate an oversized name instead of failing", func() {
+			specRun := &domain.SpecRun{
+				SuiteRunID: 1,
+				Name:       strings.Repeat("a", domain.MaxNameLengthBytes+256),
+			}
+
+			mockSpecRepo.On("Create", ctx, mock.MatchedBy(func(s *domain.SpecRun) bool {
+				return len(s.Name) == domain.MaxNameLengthBytes
+			})).Return(nil)
+
+			err := service.CreateSpecRun(ctx, specRun)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockSpecRepo.AssertExpectations(GinkgoT())
 		})
 
 		It("should calculate duration from start and end time", func() {

--- a/internal/domains/testing/domain/name_truncation.go
+++ b/internal/domains/testing/domain/name_truncation.go
@@ -1,0 +1,51 @@
+package domain
+
+import "unicode/utf8"
+
+const (
+	// MaxNameLengthBytes bounds spec/suite/tag names by UTF-8 byte length
+	// (not rune count) before they're persisted. spec_runs.spec_name and
+	// suite_runs.suite_name are both indexed, and tags.name carries a
+	// unique constraint backed by an index -- Postgres B-tree index
+	// entries have a hard ceiling around 2704 bytes (1/3 of an 8KB
+	// page), and exceeding it fails the insert with "index row size ...
+	// exceeds btree version 4 maximum 2704", regardless of the TEXT
+	// column widening. A rune-counted bound doesn't protect against
+	// that: a 2048-*rune* name can be up to 8192 bytes for 4-byte-per-
+	// rune content (emoji, some CJK), which still blows the index limit
+	// and reintroduces the batch-insert failure this fix exists to
+	// close. Bounding by byte length directly ties the limit to what
+	// Postgres actually enforces; 2048 bytes leaves solid headroom under
+	// 2704 regardless of the name's character mix.
+	// See https://github.com/guidewire-oss/fern-platform/issues/230.
+	MaxNameLengthBytes = 2048
+
+	// TruncationMarker is appended to any name that TruncateName had to
+	// shorten, so a truncated name is visibly distinguishable from one
+	// that was always short.
+	TruncationMarker = " …[truncated]"
+)
+
+// TruncateName bounds name to MaxNameLengthBytes UTF-8 bytes, appending
+// TruncationMarker when it had to cut something off. The cut point is
+// backed off to the nearest rune boundary so a multi-byte character is
+// never split in half, which would otherwise corrupt the string's UTF-8
+// encoding.
+//
+// This lives in the domain package (rather than application, where the
+// spec/suite-name callers are) so both the application layer and the
+// infrastructure layer -- which is where tag names are converted for
+// persistence -- can call it without infrastructure having to depend on
+// application, which would invert the normal dependency direction.
+func TruncateName(name string) string {
+	if len(name) <= MaxNameLengthBytes {
+		return name
+	}
+
+	keep := max(MaxNameLengthBytes-len(TruncationMarker), 0)
+	for keep > 0 && !utf8.RuneStart(name[keep]) {
+		keep--
+	}
+
+	return name[:keep] + TruncationMarker
+}

--- a/internal/domains/testing/infrastructure/database_converter.go
+++ b/internal/domains/testing/infrastructure/database_converter.go
@@ -208,7 +208,15 @@ func (c *DatabaseConverter) ConvertSpecRunToDomain(dbSpec *database.SpecRun) *do
 	}
 }
 
-// ConvertDomainTagsToDatabase converts domain tags to database tags
+// ConvertDomainTagsToDatabase converts domain tags to database tags.
+// Names are bounded via domain.TruncateName -- this is the single choke
+// point every run/suite/spec-level tag passes through on its way to a
+// repository write (see ConvertTestRunToDatabase and the SuiteRun/SpecRun
+// converters below), so tags.name's unique index can't crash the batch
+// the same way spec_name/suite_name did before issue #230's fix. A tag
+// with an already-resolved ID (looked up or created earlier via the
+// tags service) is unaffected by truncation here: its name was already
+// normalized before that lookup, and TruncateName is idempotent.
 func (c *DatabaseConverter) ConvertDomainTagsToDatabase(domainTags []domain.Tag) []database.Tag {
 	if len(domainTags) == 0 {
 		return nil
@@ -220,7 +228,7 @@ func (c *DatabaseConverter) ConvertDomainTagsToDatabase(domainTags []domain.Tag)
 			BaseModel: database.BaseModel{
 				ID: tag.ID,
 			},
-			Name:     tag.Name,
+			Name:     domain.TruncateName(tag.Name),
 			Category: tag.Category,
 			Value:    tag.Value,
 		}

--- a/internal/domains/testing/infrastructure/database_converter_test.go
+++ b/internal/domains/testing/infrastructure/database_converter_test.go
@@ -1,6 +1,7 @@
 package infrastructure_test
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -477,6 +478,23 @@ var _ = Describe("DatabaseConverter", func() {
 		It("should return nil for nil domain tags", func() {
 			dbTags := converter.ConvertDomainTagsToDatabase(nil)
 			Expect(dbTags).To(BeNil())
+		})
+
+		It("should truncate an oversized tag name instead of passing it straight to the DB", func() {
+			// tags.name carries a unique index, so an oversized value hits
+			// the same Postgres B-tree size ceiling as spec_name/suite_name
+			// -- this is the single choke point every run/suite/spec-level
+			// tag passes through before a repository write, so bounding it
+			// here covers all of them. See issue #230.
+			longName := strings.Repeat("a", domain.MaxNameLengthBytes+256)
+
+			dbTags := converter.ConvertDomainTagsToDatabase([]domain.Tag{
+				{ID: 1, Name: longName, Category: "priority", Value: "high"},
+			})
+
+			Expect(dbTags).To(HaveLen(1))
+			Expect(len(dbTags[0].Name)).To(Equal(domain.MaxNameLengthBytes))
+			Expect(dbTags[0].Name).To(HaveSuffix(domain.TruncationMarker))
 		})
 	})
 

--- a/migrations/000025_widen_name_columns.down.sql
+++ b/migrations/000025_widen_name_columns.down.sql
@@ -1,0 +1,20 @@
+-- Lossy, best-effort rollback: any spec_name/suite_name/tag name longer
+-- than 255 characters is truncated to fit rather than aborting the
+-- migration and forcing an operator to find and delete/edit the
+-- offending rows by hand first.
+--
+-- tags.name additionally carries a UNIQUE constraint. Two distinct long
+-- tag names that happen to share the same first-255-character prefix
+-- would collide once both are truncated to that prefix, which would
+-- otherwise abort the ALTER with a duplicate-key error. Disambiguate
+-- every tag row that needs truncation by appending "~<id>" -- id is the
+-- primary key, so it's guaranteed unique per row regardless of what any
+-- other row's name is, which means this can never itself produce a
+-- collision. Only rows that actually need truncation are touched.
+UPDATE tags
+SET name = left(name, 255 - (length(id::text) + 1)) || '~' || id::text
+WHERE length(name) > 255;
+
+ALTER TABLE tags ALTER COLUMN name TYPE VARCHAR(255) USING left(name, 255);
+ALTER TABLE suite_runs ALTER COLUMN suite_name TYPE VARCHAR(255) USING left(suite_name, 255);
+ALTER TABLE spec_runs ALTER COLUMN spec_name TYPE VARCHAR(255) USING left(spec_name, 255);

--- a/migrations/000025_widen_name_columns.up.sql
+++ b/migrations/000025_widen_name_columns.up.sql
@@ -1,0 +1,11 @@
+-- Widen name columns that were capped at VARCHAR(255) with no
+-- truncation/validation before insert. BDD frameworks (Ginkgo, Jasmine,
+-- RSpec, ...) build spec/suite names from nested Describe/Context/It
+-- text and routinely exceed 255 characters, which made Postgres reject
+-- the whole batch insert with "value too long for type character
+-- varying(255)" (SQLSTATE 22001) -- silently discarding every spec in
+-- the submission, including ones that ran and passed.
+-- See https://github.com/guidewire-oss/fern-platform/issues/230.
+ALTER TABLE spec_runs ALTER COLUMN spec_name TYPE TEXT;
+ALTER TABLE suite_runs ALTER COLUMN suite_name TYPE TEXT;
+ALTER TABLE tags ALTER COLUMN name TYPE TEXT;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents batch rejection from oversized spec/suite/tag names by widening DB columns to TEXT and truncating long names on ingest. Previously names >255 chars caused Postgres errors and a 400 response; now names are UTF-8-safe truncated to 2048 bytes with a " …[truncated]" marker, and the run is saved with a 201.

**Migration**
- Apply migration 000025 to convert `spec_runs.spec_name`, `suite_runs.suite_name`, and `tags.name` to TEXT.
- Truncation is centralized in `domain.TruncateName` (2048-byte limit, cut at a rune boundary) and applied during validation, on every create/append path, and before tag lookups and inserts so unique-index checks always see normalized names.
- The down migration is lossy but automated: values are truncated to ≤255 and `tags.name` collisions are disambiguated by appending `~<id>` before reverting to VARCHAR(255).

<sup>Written for commit a87d94ed79b68624522cee2ff6de6d107bb07218. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/fern-platform/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

